### PR TITLE
Async Connection#write

### DIFF
--- a/lib/punchblock/protocol/ozone.rb
+++ b/lib/punchblock/protocol/ozone.rb
@@ -21,6 +21,7 @@ module Punchblock
       autoload :OzoneNode
       autoload :Ref
 
+      Ref # FIXME: Force autoload Ref so it gets registered properly
       ##
       # Create a new protocol object with which to communicate with the Ozone server.
       # See Ozone::Connection for details of options


### PR DESCRIPTION
What's happened is that I've essentially flipped the write method inside out. Now instead of blocking on an internal queue for a response and then handling it synchronously, we define a callback to be used when a response is received. In order to provide a synchronous feel, we create a queue to which the callback pushes what used to be the return value of Connection#write (either true or an exception). We then return this from Connection#async_write in order that the synchronous version may block on the queue (with the timeout).

I still don't really like this approach since it's still blocking in the synchronous version. As far as I am aware, this is the best we can do with Ruby 1.8.x. The improvement in order to provide a synchronous API while actually not blocking under the hood would require Fibers. It should be possible to provide a different version of Connection#write depending on the availability of Fibers. I'll look into this more later.
