### PR TITLE
Replacing mixer_id with mixer_name

### DIFF
--- a/lib/punchblock/command/join.rb
+++ b/lib/punchblock/command/join.rb
@@ -8,7 +8,7 @@ module Punchblock
       #
       # @param [Hash] options
       # @option options [String, Optional] :other_call_id the call ID to join
-      # @option options [String, Optional] :mixer_id the mixer name to join
+      # @option options [String, Optional] :mixer_name the mixer name to join
       # @option options [Symbol, Optional] :direction the direction in which media should flow
       # @option options [Symbol, Optional] :media the method by which to negotiate media
       #
@@ -39,14 +39,14 @@ module Punchblock
 
       ##
       # @return [String] the mixer name to join
-      def mixer_id
-        read_attr :'mixer-id'
+      def mixer_name
+        read_attr :'mixer-name'
       end
 
       ##
       # @param [String] other the mixer name to join
-      def mixer_id=(other)
-        write_attr :'mixer-id', other
+      def mixer_name=(other)
+        write_attr :'mixer-name', other
       end
 
       ##
@@ -74,7 +74,7 @@ module Punchblock
       end
 
       def inspect_attributes # :nodoc:
-        [:other_call_id, :mixer_id, :direction, :media] + super
+        [:other_call_id, :mixer_name, :direction, :media] + super
       end
     end # Join
   end # Command

--- a/lib/punchblock/command/unjoin.rb
+++ b/lib/punchblock/command/unjoin.rb
@@ -8,7 +8,7 @@ module Punchblock
       #
       # @param [Hash] options
       # @option options [String, Optional] :other_call_id the call ID to unjoin
-      # @option options [String, Optional] :mixer_id the mixer name to unjoin
+      # @option options [String, Optional] :mixer_name the mixer name to unjoin
       #
       # @return [Command::Unjoin] a formatted Rayo unjoin command
       #
@@ -32,18 +32,18 @@ module Punchblock
 
       ##
       # @return [String] the mixer name to unjoin
-      def mixer_id
-        read_attr :'mixer-id'
+      def mixer_name
+        read_attr :'mixer-name'
       end
 
       ##
       # @param [String] other the mixer name to unjoin
-      def mixer_id=(other)
-        write_attr :'mixer-id', other
+      def mixer_name=(other)
+        write_attr :'mixer-name', other
       end
 
       def inspect_attributes # :nodoc:
-        [:other_call_id, :mixer_id] + super
+        [:other_call_id, :mixer_name] + super
       end
     end # Unjoin
   end # Command

--- a/lib/punchblock/event/joined.rb
+++ b/lib/punchblock/event/joined.rb
@@ -8,7 +8,7 @@ module Punchblock
       #
       # @param [Hash] options
       # @option options [String, Optional] :other_call_id the call ID that was joined
-      # @option options [String, Optional] :mixer_id the mixer name that was joined
+      # @option options [String, Optional] :mixer_name the mixer name that was joined
       #
       # @return [Event::Joined] a formatted Rayo joined event
       #
@@ -32,18 +32,18 @@ module Punchblock
 
       ##
       # @return [String] the mixer name that was joined
-      def mixer_id
-        read_attr :'mixer-id'
+      def mixer_name
+        read_attr :'mixer-name'
       end
 
       ##
       # @param [String] other the mixer name that was joined
-      def mixer_id=(other)
-        write_attr :'mixer-id', other
+      def mixer_name=(other)
+        write_attr :'mixer-name', other
       end
 
       def inspect_attributes # :nodoc:
-        [:other_call_id, :mixer_id] + super
+        [:other_call_id, :mixer_name] + super
       end
     end # Joined
   end

--- a/lib/punchblock/event/unjoined.rb
+++ b/lib/punchblock/event/unjoined.rb
@@ -8,7 +8,7 @@ module Punchblock
       #
       # @param [Hash] options
       # @option options [String, Optional] :other_call_id the call ID that was unjoined
-      # @option options [String, Optional] :mixer_id the mixer name that was unjoined
+      # @option options [String, Optional] :mixer_name the mixer name that was unjoined
       #
       # @return [Event::Unjoined] a formatted Rayo unjoined event
       #
@@ -32,18 +32,18 @@ module Punchblock
 
       ##
       # @return [String] the mixer name that was unjoined
-      def mixer_id
-        read_attr :'mixer-id'
+      def mixer_name
+        read_attr :'mixer-name'
       end
 
       ##
       # @param [String] other the mixer name that was unjoined
-      def mixer_id=(other)
-        write_attr :'mixer-id', other
+      def mixer_name=(other)
+        write_attr :'mixer-name', other
       end
 
       def inspect_attributes # :nodoc:
-        [:other_call_id, :mixer_id] + super
+        [:other_call_id, :mixer_name] + super
       end
     end # Unjoined
   end

--- a/spec/punchblock/command/join_spec.rb
+++ b/spec/punchblock/command/join_spec.rb
@@ -9,10 +9,10 @@ module Punchblock
       end
 
       describe "when setting options in initializer" do
-        subject { Join.new :other_call_id => 'abc123', :mixer_id => 'blah', :direction => :duplex, :media => :bridge }
+        subject { Join.new :other_call_id => 'abc123', :mixer_name => 'blah', :direction => :duplex, :media => :bridge }
 
         its(:other_call_id) { should == 'abc123' }
-        its(:mixer_id)      { should == 'blah' }
+        its(:mixer_name)      { should == 'blah' }
         its(:direction)     { should == :duplex }
         its(:media)         { should == :bridge }
       end
@@ -22,7 +22,7 @@ module Punchblock
           <<-MESSAGE
 <join xmlns="urn:xmpp:rayo:1"
       call-id="abc123"
-      mixer-id="blah"
+      mixer-name="blah"
       direction="duplex"
       media="bridge" />
           MESSAGE
@@ -33,7 +33,7 @@ module Punchblock
         it { should be_instance_of Join }
 
         its(:other_call_id) { should == 'abc123' }
-        its(:mixer_id)      { should == 'blah' }
+        its(:mixer_name)      { should == 'blah' }
         its(:direction)     { should == :duplex }
         its(:media)         { should == :bridge }
       end

--- a/spec/punchblock/command/unjoin_spec.rb
+++ b/spec/punchblock/command/unjoin_spec.rb
@@ -9,10 +9,10 @@ module Punchblock
       end
 
       describe "when setting options in initializer" do
-        subject { Unjoin.new :other_call_id => 'abc123', :mixer_id => 'blah' }
+        subject { Unjoin.new :other_call_id => 'abc123', :mixer_name => 'blah' }
 
         its(:other_call_id) { should == 'abc123' }
-        its(:mixer_id)      { should == 'blah' }
+        its(:mixer_name)      { should == 'blah' }
       end
 
       describe "from a stanza" do
@@ -20,7 +20,7 @@ module Punchblock
           <<-MESSAGE
 <unjoin xmlns="urn:xmpp:rayo:1"
       call-id="abc123"
-      mixer-id="blah" />
+      mixer-name="blah" />
           MESSAGE
         end
 
@@ -29,7 +29,7 @@ module Punchblock
         it { should be_instance_of Unjoin }
 
         its(:other_call_id) { should == 'abc123' }
-        its(:mixer_id)      { should == 'blah' }
+        its(:mixer_name)      { should == 'blah' }
       end
     end
   end

--- a/spec/punchblock/event/joined_spec.rb
+++ b/spec/punchblock/event/joined_spec.rb
@@ -8,7 +8,7 @@ module Punchblock
       end
 
       describe "from a stanza" do
-        let(:stanza) { '<joined xmlns="urn:xmpp:rayo:1" call-id="b" mixer-id="m" />' }
+        let(:stanza) { '<joined xmlns="urn:xmpp:rayo:1" call-id="b" mixer-name="m" />' }
 
         subject { RayoNode.import parse_stanza(stanza).root, '9f00061', '1' }
 
@@ -17,15 +17,15 @@ module Punchblock
         it_should_behave_like 'event'
 
         its(:other_call_id) { should == 'b' }
-        its(:mixer_id)      { should == 'm' }
+        its(:mixer_name)      { should == 'm' }
         its(:xmlns)         { should == 'urn:xmpp:rayo:1' }
       end
 
       describe "when setting options in initializer" do
-        subject { Joined.new :other_call_id => 'abc123', :mixer_id => 'blah' }
+        subject { Joined.new :other_call_id => 'abc123', :mixer_name => 'blah' }
 
         its(:other_call_id) { should == 'abc123' }
-        its(:mixer_id)      { should == 'blah' }
+        its(:mixer_name)      { should == 'blah' }
       end
     end
   end

--- a/spec/punchblock/event/unjoined_spec.rb
+++ b/spec/punchblock/event/unjoined_spec.rb
@@ -8,7 +8,7 @@ module Punchblock
       end
 
       describe "from a stanza" do
-        let(:stanza) { '<unjoined xmlns="urn:xmpp:rayo:1" call-id="b" mixer-id="m" />' }
+        let(:stanza) { '<unjoined xmlns="urn:xmpp:rayo:1" call-id="b" mixer-name="m" />' }
 
         subject { RayoNode.import parse_stanza(stanza).root, '9f00061', '1' }
 
@@ -17,15 +17,15 @@ module Punchblock
         it_should_behave_like 'event'
 
         its(:other_call_id) { should == 'b' }
-        its(:mixer_id)      { should == 'm' }
+        its(:mixer_name)      { should == 'm' }
         its(:xmlns)         { should == 'urn:xmpp:rayo:1' }
       end
 
       describe "when setting options in initializer" do
-        subject { Unjoined.new :other_call_id => 'abc123', :mixer_id => 'blah' }
+        subject { Unjoined.new :other_call_id => 'abc123', :mixer_name => 'blah' }
 
         its(:other_call_id) { should == 'abc123' }
-        its(:mixer_id)      { should == 'blah' }
+        its(:mixer_name)      { should == 'blah' }
       end
     end
   end


### PR DESCRIPTION
Rayo is currently using "mixer_name" attribute instead "mixer_id"
