### PR TITLE
[FEATURE] Join command now enforces a list of valid direction attribute values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [develop](https://github.com/adhearsion/punchblock)
+  * Feature: Join command now enforces a list of valid direction attribute values.
 
 # [v1.7.1](https://github.com/adhearsion/punchblock/compare/v1.7.0...v1.7.1) - [2012-12-17](https://rubygems.org/gems/punchblock/versions/1.7.1)
   * Bugfix: Deal with nil media engines on FS/* properly

--- a/lib/punchblock/command/join.rb
+++ b/lib/punchblock/command/join.rb
@@ -5,6 +5,8 @@ module Punchblock
     class Join < CommandNode
       register :join, :core
 
+      VALID_DIRECTIONS = [:duplex, :send, :recv].freeze
+
       ##
       # Create a join command
       #
@@ -59,8 +61,11 @@ module Punchblock
 
       ##
       # @param [String] other the direction in which media should flow. Can be :duplex, :recv or :send
-      def direction=(other)
-        write_attr :direction, other
+      def direction=(direction)
+        if direction && !VALID_DIRECTIONS.include?(direction.to_sym)
+          raise ArgumentError, "Invalid Direction (#{direction}), use: #{VALID_DIRECTIONS*' '}"
+        end
+        write_attr :direction, direction 
       end
 
       ##

--- a/spec/punchblock/command/join_spec.rb
+++ b/spec/punchblock/command/join_spec.rb
@@ -39,6 +39,28 @@ module Punchblock
         its(:direction)   { should be == :duplex }
         its(:media)       { should be == :bridge }
       end
+
+      describe "with a direction" do
+        [nil, :duplex, :send, :recv].each do |direction|
+          describe direction do
+            subject { Join.new :direction => direction }
+
+            its(:direction) { should be == direction }
+          end
+        end
+
+        describe "no direction" do
+          subject { Join.new }
+
+          its(:direction) { should be_nil }
+        end
+
+        describe "blahblahblah" do
+          it "should raise an error" do
+            expect { Join.new(:direction => :blahblahblah) }.to raise_error ArgumentError
+          end
+        end
+      end
     end
   end
 end # Punchblock


### PR DESCRIPTION
This is in line with the Rayo spec and what other components and commands already do.
