### PR TITLE
[BUGFIX] Fixed answering during early media on FS.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
   * Feature: Join command now enforces a list of valid direction attribute values.
   * Feature: added support for media direction to the Record component
   * Feature: Record direction support on FS
+  * Bugfix: Fixed answering during early media on FS
 
 # [v1.7.1](https://github.com/adhearsion/punchblock/compare/v1.7.0...v1.7.1) - [2012-12-17](https://rubygems.org/gems/punchblock/versions/1.7.1)
   * Bugfix: Deal with nil media engines on FS/* properly

--- a/lib/punchblock/translator/freeswitch/call.rb
+++ b/lib/punchblock/translator/freeswitch/call.rb
@@ -104,6 +104,7 @@ module Punchblock
             if component = component_with_id(event[:scope_variable_punchblock_component_id])
               safe_from_dead_actors { component.handle_es_event event if component.alive? }
             end
+            throw :pass
           end
         end
 


### PR DESCRIPTION
As extensively discussed, the handler was not passing to continue execution.
