### PR TITLE
[BUGFIX] Asterisk translator now properly checks for the existance of

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # [develop](https://github.com/adhearsion/punchblock)
+  * Bugfix: Asterisk translator now properly checks for existence of the recordings directory
+  * Bugfix: XMPP specs were mistakenly resetting the logger object for other tests.
 
 # [v1.8.0](https://github.com/adhearsion/punchblock/compare/v1.7.1...v1.8.0) - [2013-01-10](https://rubygems.org/gems/punchblock/versions/1.8.0)
   * Feature: Join command now enforces a list of valid direction attribute values

--- a/lib/punchblock/translator/asterisk.rb
+++ b/lib/punchblock/translator/asterisk.rb
@@ -149,10 +149,11 @@ module Punchblock
             pb_logger.error "Punchblock failed to add the #{REDIRECT_EXTENSION} extension to the #{REDIRECT_CONTEXT} context. Please add a [#{REDIRECT_CONTEXT}] entry to your dialplan."
           end
         end
+        check_recording_directory
       end
 
       def check_recording_directory
-        pb_logger.warning "Recordings directory #{Component::Record::RECORDING_BASE_PATH} does not exist. Recording might not work. This warning can be ignored if Adhearsion is running on a separate machine than Asterisk. See http://adhearsion.com/docs/call-controllers#recording" unless File.exists?(Component::Record::RECORDING_BASE_PATH)
+        pb_logger.warn "Recordings directory #{Component::Record::RECORDING_BASE_PATH} does not exist. Recording might not work. This warning can be ignored if Adhearsion is running on a separate machine than Asterisk. See http://adhearsion.com/docs/call-controllers#recording" unless File.exists?(Component::Record::RECORDING_BASE_PATH)
       end
 
       def actor_died(actor, reason)

--- a/spec/punchblock/connection/xmpp_spec.rb
+++ b/spec/punchblock/connection/xmpp_spec.rb
@@ -64,10 +64,11 @@ module Punchblock
       end
 
       it 'should properly set the Blather logger' do
+        old_logger = Punchblock.logger
         Punchblock.logger = :foo
         XMPP.new :username => '1@call.rayo.net', :password => 1
         Blather.logger.should be :foo
-        Punchblock.reset_logger
+        Punchblock.logger = old_logger
       end
 
       it "looking up original command by command ID" do


### PR DESCRIPTION
the recording directory. XMPP specs were mistakenly resetting the logger
object for other tests.

Fixes #130
