### PR TITLE
[BUGFIX] Fix menus by adding missing NLSML instance tag

### DIFF
--- a/lib/punchblock/translator/input_component.rb
+++ b/lib/punchblock/translator/input_component.rb
@@ -65,6 +65,7 @@ module Punchblock
       def success_reason(match)
         nlsml = RubySpeech::NLSML.draw do
           interpretation confidence: match.confidence do
+            instance match.interpretation
             input match.utterance, mode: match.mode
           end
         end

--- a/spec/punchblock/translator/asterisk/component/composed_prompt_spec.rb
+++ b/spec/punchblock/translator/asterisk/component/composed_prompt_spec.rb
@@ -145,6 +145,7 @@ module Punchblock
                   let :expected_nlsml do
                     RubySpeech::NLSML.draw do
                       interpretation confidence: 1 do
+                        instance "dtmf-1"
                         input "1", mode: :dtmf
                       end
                     end

--- a/spec/punchblock/translator/asterisk/component/input_spec.rb
+++ b/spec/punchblock/translator/asterisk/component/input_spec.rb
@@ -82,6 +82,7 @@ module Punchblock
                 let :expected_nlsml do
                   RubySpeech::NLSML.draw do
                     interpretation confidence: 1 do
+                      instance "dtmf-1 dtmf-2"
                       input "12", mode: :dtmf
                     end
                   end
@@ -193,6 +194,7 @@ module Punchblock
                 let :expected_nlsml do
                   RubySpeech::NLSML.draw do
                     interpretation confidence: 1 do
+                      instance "dtmf-1 dtmf-2"
                       input "12", mode: :dtmf
                     end
                   end
@@ -355,6 +357,7 @@ module Punchblock
                     let :expected_nlsml do
                       RubySpeech::NLSML.draw do
                         interpretation confidence: 1 do
+                          instance "dtmf-1 dtmf-1"
                           input '11', mode: :dtmf
                         end
                       end

--- a/spec/punchblock/translator/freeswitch/component/input_spec.rb
+++ b/spec/punchblock/translator/freeswitch/component/input_spec.rb
@@ -77,6 +77,7 @@ module Punchblock
                 let :expected_nlsml do
                   RubySpeech::NLSML.draw do
                     interpretation confidence: 1 do
+                      instance "dtmf-1 dtmf-2"
                       input "12", mode: :dtmf
                     end
                   end


### PR DESCRIPTION
I hadn't even heard of NLSML until today but if my understanding is correct, the instance tag is required for menus to work. The interpretation value was coming through as nil, causing the first match statement to always be chosen.
