### PR TITLE
Execute call components within the call actor

### DIFF
--- a/lib/punchblock/translator/freeswitch/call.rb
+++ b/lib/punchblock/translator/freeswitch/call.rb
@@ -207,11 +207,11 @@ module Punchblock
             media_renderer = command.renderer || media_engine || :freeswitch
             case media_renderer.to_sym
             when :freeswitch, :native, nil
-              execute_component Component::Output, command
+              execute_inline_component Component::Output, command
             when :flite
-              execute_component Component::FliteOutput, command, media_engine, default_voice
+              execute_inline_component Component::FliteOutput, command, media_engine, default_voice
             else
-              execute_component Component::TTSOutput, command, media_engine, default_voice
+              execute_inline_component Component::TTSOutput, command, media_engine, default_voice
             end
           when Punchblock::Component::Input
             execute_component Component::Input, command
@@ -250,6 +250,13 @@ module Punchblock
 
         def execute_component(type, command, *execute_args)
           type.new_link(command, current_actor).tap do |component|
+            register_component component
+            component.execute(*execute_args)
+          end
+        end
+
+        def execute_inline_component(type, command, *execute_args)
+          type.new(command, self).tap do |component|
             register_component component
             component.execute(*execute_args)
           end

--- a/lib/punchblock/translator/freeswitch/component.rb
+++ b/lib/punchblock/translator/freeswitch/component.rb
@@ -8,85 +8,21 @@ module Punchblock
 
         autoload :AbstractOutput
         autoload :FliteOutput
+        autoload :InlineComponent
         autoload :Input
         autoload :Output
         autoload :Record
         autoload :TTSOutput
 
-        class Component
+        class Component < InlineComponent
           include Celluloid
-          include DeadActorSafety
-          include HasGuardedHandlers
 
           extend ActorHasGuardedHandlers
           execute_guarded_handlers_on_receiver
 
-          attr_reader :id, :call, :call_id
-
-          def initialize(component_node, call = nil)
-            @component_node, @call = component_node, call
-            @call_id = safe_from_dead_actors { call.id } if call
-            @id = Punchblock.new_uuid
-            @complete = false
-            setup
-          end
-
-          def setup
-          end
-
-          def execute_command(command)
-            command.response = ProtocolError.new.setup 'command-not-acceptable', "Did not understand command for component #{id}", call_id, id
-          end
-
-          def handle_es_event(event)
-            trigger_handler :es, event
-          end
-
-          def send_complete_event(reason, recording = nil)
-            return if @complete
-            @complete = true
-            event = Punchblock::Event::Complete.new.tap do |c|
-              c.reason = reason
-              c << recording if recording
-            end
-            send_event event
+          def send_complete_event(*args)
+            super
             terminate
-          end
-
-          def send_event(event)
-            event.component_id    = id
-            event.target_call_id  = call_id
-            safe_from_dead_actors { translator.handle_pb_event event }
-          end
-
-          def logger_id
-            "#{self.class}: #{call_id ? "Call ID: #{call_id}, Component ID: #{id}" : id}"
-          end
-
-          def call_ended
-            send_complete_event Punchblock::Event::Complete::Hangup.new
-          end
-
-          def application(appname, options = nil)
-            call.application appname, "%[punchblock_component_id=#{id}]#{options}"
-          end
-
-          private
-
-          def translator
-            call.translator
-          end
-
-          def set_node_response(value)
-            @component_node.response = value
-          end
-
-          def send_ref
-            set_node_response Ref.new :id => id
-          end
-
-          def with_error(name, text)
-            set_node_response ProtocolError.new.setup(name, text)
           end
         end
       end

--- a/lib/punchblock/translator/freeswitch/component/abstract_output.rb
+++ b/lib/punchblock/translator/freeswitch/component/abstract_output.rb
@@ -4,7 +4,7 @@ module Punchblock
   module Translator
     class Freeswitch
       module Component
-        class AbstractOutput < Component
+        class AbstractOutput < InlineComponent
           UnrenderableDocError = Class.new OptionError
 
           def execute(*args)

--- a/lib/punchblock/translator/freeswitch/component/inline_component.rb
+++ b/lib/punchblock/translator/freeswitch/component/inline_component.rb
@@ -1,0 +1,85 @@
+# encoding: utf-8
+
+module Punchblock
+  module Translator
+    class Freeswitch
+      module Component
+        class InlineComponent
+          include DeadActorSafety
+          include HasGuardedHandlers
+
+          attr_reader :id, :call, :call_id
+
+          def initialize(component_node, call)
+            @component_node, @call = component_node, call
+            @call_id = safe_from_dead_actors { call.id } if call
+            @id = Punchblock.new_uuid
+            @complete = false
+            setup
+          end
+
+          def setup
+          end
+
+          def execute_command(command)
+            command.response = ProtocolError.new.setup 'command-not-acceptable', "Did not understand command for component #{id}", call_id, id
+          end
+
+          def handle_es_event(event)
+            trigger_handler :es, event
+          end
+
+          def send_complete_event(reason, recording = nil)
+            return if @complete
+            @complete = true
+            event = Punchblock::Event::Complete.new.tap do |c|
+              c.reason = reason
+              c << recording if recording
+            end
+            send_event event
+          end
+
+          def send_event(event)
+            event.component_id    = id
+            event.target_call_id  = call_id
+            safe_from_dead_actors { translator.handle_pb_event event }
+          end
+
+          def logger_id
+            "#{self.class}: #{call_id ? "Call ID: #{call_id}, Component ID: #{id}" : id}"
+          end
+
+          def call_ended
+            send_complete_event Punchblock::Event::Complete::Hangup.new
+          end
+
+          def application(appname, options = nil)
+            call.application appname, "%[punchblock_component_id=#{id}]#{options}"
+          end
+
+          def alive?
+            true
+          end
+
+          private
+
+          def translator
+            call.translator
+          end
+
+          def set_node_response(value)
+            @component_node.response = value
+          end
+
+          def send_ref
+            set_node_response Ref.new :id => id
+          end
+
+          def with_error(name, text)
+            set_node_response ProtocolError.new.setup(name, text)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/punchblock/translator/freeswitch/call_spec.rb
+++ b/spec/punchblock/translator/freeswitch/call_spec.rb
@@ -776,12 +776,14 @@ module Punchblock
 
             let(:mock_component) { Translator::Freeswitch::Component::Output.new(command, subject) }
 
+            before { mock_component }
+
             ['freeswitch', nil].each do |media_engine|
               let(:media_engine) { media_engine }
 
               context "with a media engine of #{media_engine}" do
                 it 'should create an Output component and execute it asynchronously' do
-                  Component::Output.should_receive(:new_link).once.with(command, subject).and_return mock_component
+                  Component::Output.should_receive(:new).with(command, subject.wrapped_object).and_return mock_component
                   mock_component.should_receive(:execute).once
                   subject.execute_command command
                   subject.component_with_id(mock_component.id).should be mock_component
@@ -793,7 +795,7 @@ module Punchblock
               let(:media_engine) { :flite }
 
               it 'should create a FliteOutput component and execute it asynchronously using flite and the calls default voice' do
-                Component::FliteOutput.should_receive(:new_link).once.with(command, subject).and_return mock_component
+                Component::FliteOutput.should_receive(:new).with(command, subject.wrapped_object).and_return mock_component
                 mock_component.should_receive(:execute).once.with(media_engine, default_voice)
                 subject.execute_command command
                 subject.component_with_id(mock_component.id).should be mock_component
@@ -804,7 +806,7 @@ module Punchblock
               let(:media_engine) { :cepstral }
 
               it 'should create a TTSOutput component and execute it asynchronously using cepstral and the calls default voice' do
-                Component::TTSOutput.should_receive(:new_link).once.with(command, subject).and_return mock_component
+                Component::TTSOutput.should_receive(:new).with(command, subject.wrapped_object).and_return mock_component
                 mock_component.should_receive(:execute).once.with(media_engine, default_voice)
                 subject.execute_command command
                 subject.component_with_id(mock_component.id).should be mock_component
@@ -815,7 +817,7 @@ module Punchblock
               let(:media_engine) { :unimrcp }
 
               it 'should create a TTSOutput component and execute it asynchronously using unimrcp and the calls default voice' do
-                Component::TTSOutput.should_receive(:new_link).once.with(command, subject).and_return mock_component
+                Component::TTSOutput.should_receive(:new).with(command, subject.wrapped_object).and_return mock_component
                 mock_component.should_receive(:execute).once.with(media_engine, default_voice)
                 subject.execute_command command
                 subject.component_with_id(mock_component.id).should be mock_component
@@ -830,7 +832,7 @@ module Punchblock
               end
 
               it "should use the component media engine and not the platform one if it is set" do
-                Component::Output.should_receive(:new_link).once.with(command_with_renderer, subject).and_return mock_component
+                Component::Output.should_receive(:new).with(command_with_renderer, subject.wrapped_object).and_return mock_component
                 mock_component.should_receive(:execute).once
                 subject.execute_command command_with_renderer
                 subject.component_with_id(mock_component.id).should be mock_component
@@ -888,7 +890,7 @@ module Punchblock
 
             context "for a component which began executing but crashed" do
               let :component_command do
-                Punchblock::Component::Output.new :ssml => RubySpeech::SSML.draw
+                Punchblock::Component::Input.new mode: :dtmf, grammar: { value: RubySpeech::GRXML.draw }
               end
 
               let(:comp_id) { component_command.response.id }

--- a/spec/punchblock/translator/freeswitch/component/flite_output_spec.rb
+++ b/spec/punchblock/translator/freeswitch/component/flite_output_spec.rb
@@ -37,7 +37,7 @@ module Punchblock
           describe '#execute' do
             before { original_command.request! }
             def expect_playback(voice = :kal)
-              subject.wrapped_object.should_receive(:application).once.with :speak, "#{media_engine}|#{voice}|FOO"
+              subject.should_receive(:application).once.with :speak, "#{media_engine}|#{voice}|FOO"
             end
 
             let(:command_opts) { {} }
@@ -249,13 +249,13 @@ module Punchblock
               end
 
               it "sets the command response to true" do
-                subject.wrapped_object.should_receive(:application)
+                subject.should_receive(:application)
                 subject.execute_command command
                 command.response(0.1).should be == true
               end
 
               it "sends the correct complete event" do
-                subject.wrapped_object.should_receive(:application)
+                subject.should_receive(:application)
                 original_command.should_not be_complete
                 subject.execute_command command
                 reason.should be_a Punchblock::Event::Complete::Stop
@@ -263,7 +263,7 @@ module Punchblock
               end
 
               it "breaks the current dialplan application" do
-                subject.wrapped_object.should_receive(:application).once.with 'break'
+                subject.should_receive(:application).once.with 'break'
                 subject.execute_command command
               end
             end

--- a/spec/punchblock/translator/freeswitch/component/output_spec.rb
+++ b/spec/punchblock/translator/freeswitch/component/output_spec.rb
@@ -31,7 +31,7 @@ module Punchblock
           describe '#execute' do
             before { original_command.request! }
             def expect_playback(filename = audio_filename)
-              subject.wrapped_object.should_receive(:application).once.with 'playback', "file_string://#{filename}"
+              subject.should_receive(:application).once.with 'playback', "file_string://#{filename}"
             end
 
             let(:audio_filename) { 'http://foo.com/bar.mp3' }
@@ -338,13 +338,13 @@ module Punchblock
               end
 
               it "sets the command response to true" do
-                subject.wrapped_object.should_receive(:application)
+                subject.should_receive(:application)
                 subject.execute_command command
                 command.response(0.1).should be == true
               end
 
               it "sends the correct complete event" do
-                subject.wrapped_object.should_receive(:application)
+                subject.should_receive(:application)
                 original_command.should_not be_complete
                 subject.execute_command command
                 reason.should be_a Punchblock::Event::Complete::Stop
@@ -352,7 +352,7 @@ module Punchblock
               end
 
               it "breaks the current dialplan application" do
-                subject.wrapped_object.should_receive(:application).once.with 'break'
+                subject.should_receive(:application).once.with 'break'
                 subject.execute_command command
               end
             end

--- a/spec/punchblock/translator/freeswitch/component/tts_output_spec.rb
+++ b/spec/punchblock/translator/freeswitch/component/tts_output_spec.rb
@@ -37,7 +37,7 @@ module Punchblock
           describe '#execute' do
             before { original_command.request! }
             def expect_playback(voice = default_voice)
-              subject.wrapped_object.should_receive(:application).once.with :speak, "#{media_engine}|#{voice}|#{ssml_doc}"
+              subject.should_receive(:application).once.with :speak, "#{media_engine}|#{voice}|#{ssml_doc}"
             end
 
             let :ssml_doc do
@@ -255,13 +255,13 @@ module Punchblock
               end
 
               it "sets the command response to true" do
-                subject.wrapped_object.should_receive(:application)
+                subject.should_receive(:application)
                 subject.execute_command command
                 command.response(0.1).should be == true
               end
 
               it "sends the correct complete event" do
-                subject.wrapped_object.should_receive(:application)
+                subject.should_receive(:application)
                 original_command.should_not be_complete
                 subject.execute_command command
                 reason.should be_a Punchblock::Event::Complete::Stop
@@ -269,7 +269,7 @@ module Punchblock
               end
 
               it "breaks the current dialplan application" do
-                subject.wrapped_object.should_receive(:application).once.with 'break'
+                subject.should_receive(:application).once.with 'break'
                 subject.execute_command command
               end
             end

--- a/spec/punchblock/translator/freeswitch_spec.rb
+++ b/spec/punchblock/translator/freeswitch_spec.rb
@@ -202,8 +202,8 @@ module Punchblock
 
       describe '#execute_component_command' do
         let(:call)            { Translator::Freeswitch::Call.new 'SIP/foo', subject }
-        let(:component_node)  { Component::Output.new }
-        let(:component)       { Translator::Freeswitch::Component::Output.new(component_node, call) }
+        let(:component_node)  { Punchblock::Component::Input.new mode: :dtmf, grammar: { value: RubySpeech::GRXML.draw } }
+        let(:component)       { Translator::Freeswitch::Component::Input.new(component_node, call) }
 
         let(:command) { Component::Stop.new.tap { |c| c.component_id = component.id } }
 


### PR DESCRIPTION
Avoids creating further actors for relatively inactive components. Currently only implemented for FreeSWITCH output components. Will reduce thread count and hopefully maximum concurrent call volume. Need to measure the performance impact of this. It'll need to be reasonably significant to offset the downside of pulling component failure into the Call. If it seems worth it, we'll do the same thing for Input/Record and perhaps Asterisk.
