### PR TITLE
[BUGFIX] Avoid crashing translators (Asterisk or FreeSWITCH) by instructing them to call back to terminated Call objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Change: `#headers` and AMI `#attributes` now do not have their names modified. A header of `'Call-ID'` will no longer be modified to `:call_id`.
   * Change: AMI Events/Actions now have `#headers(=)` rather than `#attributes(=)`
   * Change: Remove event queue
+  * Bugfix: Avoid crashing translators (Asterisk or FreeSWITCH) by instructing them to call back to terminated Call objects
 
 # [v1.9.4](https://github.com/adhearsion/punchblock/compare/v1.9.3...v1.9.4) - [2013-06-08](https://rubygems.org/gems/punchblock/versions/1.9.4)
   * Bugfix: Finish more setup before sending output ref on Asterisk

--- a/lib/punchblock/translator/asterisk.rb
+++ b/lib/punchblock/translator/asterisk.rb
@@ -35,9 +35,9 @@ module Punchblock
         @calls[call.id] ||= call
       end
 
-      def deregister_call(call)
-        @channel_to_call_id.delete call.channel
-        @calls.delete call.id
+      def deregister_call(id, channel)
+        @channel_to_call_id.delete channel
+        @calls.delete id
       end
 
       def call_with_id(call_id)

--- a/lib/punchblock/translator/asterisk/call.rb
+++ b/lib/punchblock/translator/asterisk/call.rb
@@ -310,7 +310,7 @@ module Punchblock
 
         def send_end_event(reason)
           send_pb_event Event::End.new(:reason => reason)
-          translator.deregister_call current_actor
+          translator.deregister_call id, channel
           terminate
         end
 

--- a/lib/punchblock/translator/freeswitch.rb
+++ b/lib/punchblock/translator/freeswitch.rb
@@ -34,8 +34,8 @@ module Punchblock
         @calls[call.id] ||= call
       end
 
-      def deregister_call(call)
-        @calls.delete call.id
+      def deregister_call(id)
+        @calls.delete id
       end
 
       def call_with_id(call_id)

--- a/lib/punchblock/translator/freeswitch/call.rb
+++ b/lib/punchblock/translator/freeswitch/call.rb
@@ -245,7 +245,7 @@ module Punchblock
 
         def send_end_event(reason)
           send_pb_event Event::End.new(:reason => reason)
-          translator.deregister_call current_actor
+          translator.deregister_call id
           terminate
         end
 

--- a/spec/punchblock/translator/asterisk/call_spec.rb
+++ b/spec/punchblock/translator/asterisk/call_spec.rb
@@ -301,7 +301,7 @@ module Punchblock
 
             it "de-registers the call from the translator" do
               translator.stub :handle_pb_event
-              translator.should_receive(:deregister_call).once.with(subject)
+              translator.should_receive(:deregister_call).once.with(subject.id, subject.channel)
               subject.process_ami_event ami_event
             end
 

--- a/spec/punchblock/translator/asterisk_spec.rb
+++ b/spec/punchblock/translator/asterisk_spec.rb
@@ -112,13 +112,13 @@ module Punchblock
 
         it 'should make the call inaccessible by ID' do
           subject.call_with_id(call_id).should be call
-          subject.deregister_call call
+          subject.deregister_call call_id, channel
           subject.call_with_id(call_id).should be_nil
         end
 
         it 'should make the call inaccessible by channel' do
           subject.call_for_channel(channel).should be call
-          subject.deregister_call call
+          subject.deregister_call call_id, channel
           subject.call_for_channel(channel).should be_nil
         end
       end

--- a/spec/punchblock/translator/freeswitch/call_spec.rb
+++ b/spec/punchblock/translator/freeswitch/call_spec.rb
@@ -350,7 +350,7 @@ module Punchblock
 
             it "de-registers the call from the translator" do
               translator.stub :handle_pb_event
-              translator.should_receive(:deregister_call).once.with(subject)
+              translator.should_receive(:deregister_call).once.with(id)
               subject.handle_es_event es_event
             end
 

--- a/spec/punchblock/translator/freeswitch_spec.rb
+++ b/spec/punchblock/translator/freeswitch_spec.rb
@@ -88,7 +88,7 @@ module Punchblock
 
         it 'should make the call inaccessible by ID' do
           subject.call_with_id(call_id).should be call
-          subject.deregister_call call
+          subject.deregister_call call_id
           subject.call_with_id(call_id).should be_nil
         end
       end


### PR DESCRIPTION
This was occurring occasionally when deregistering calls from the translator because the ID (and channel for *) were not passed along with the instruction and so had to be queried from the Call.
