### PR TITLE
[BUGFIX] Asterisk Prompt input timers were bust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
   * Bugfix: Allow audio file URIs with file extensions on Asterisk
   * Bugfix: Input timers were being started before output finished on Asterisk composed prompts
   * Bugfix: Input initial timers were being started on Asterisk composed prompts even if the prompt was barged
+  * Bugfix: Output was being interrupted on Asterisk composed prompts at every DTMF keypress, even if the output was already finished
 
 # [v2.0.0](https://github.com/adhearsion/punchblock/compare/v1.9.4...v2.0.0) - [2013-08-29](https://rubygems.org/gems/punchblock/versions/2.0.0)
   * Feature: Compliance with v0.2 of the published Rayo spec (http://xmpp.org/extensions/xep-0327.html)

--- a/lib/punchblock/translator/asterisk/component/composed_prompt.rb
+++ b/lib/punchblock/translator/asterisk/component/composed_prompt.rb
@@ -13,6 +13,8 @@ module Punchblock
             output_command.request!
             setup_dtmf_recognizer
 
+            @output_incomplete = true
+
             output_component = Output.new_link(output_command, @call)
             call.register_component output_component
             fut = output_component.future.execute
@@ -28,6 +30,7 @@ module Punchblock
               @barged = false
               register_dtmf_event_handler
               fut.value # Block until output is complete before starting timers
+              @output_incomplete = false
               start_timers unless @barged
             else
               fut.value # Block until output is complete before allowing input
@@ -37,7 +40,7 @@ module Punchblock
           end
 
           def process_dtmf(digit)
-            if @component_node.barge_in
+            if @component_node.barge_in && @output_incomplete
               call.async.redirect_back
               @barged = true
             end


### PR DESCRIPTION
TODO: Ensure initial timer is only started if bargein is disabled or did not occur.
