### PR TITLE
Disconnected event

### DIFF
--- a/lib/punchblock/connection.rb
+++ b/lib/punchblock/connection.rb
@@ -6,6 +6,7 @@ module Punchblock
 
     autoload :Asterisk
     autoload :Connected
+    autoload :Disconnected
     autoload :Freeswitch
     autoload :GenericConnection
     autoload :XMPP

--- a/lib/punchblock/connection/disconnected.rb
+++ b/lib/punchblock/connection/disconnected.rb
@@ -1,0 +1,20 @@
+# encoding: utf-8
+
+module Punchblock
+  module Connection
+    Disconnected = Class.new do
+      def source
+        nil
+      end
+
+      def client=(other)
+        nil
+      end
+
+      def eql?(other)
+        other.is_a? self.class
+      end
+      alias :== :eql?
+    end
+  end
+end

--- a/lib/punchblock/connection/freeswitch.rb
+++ b/lib/punchblock/connection/freeswitch.rb
@@ -18,6 +18,7 @@ module Punchblock
       def run
         pb_logger.debug "Starting the RubyFS stream"
         start_stream
+        handle_event Connection::Disconnected.new
         raise DisconnectedError
       end
 

--- a/spec/punchblock/connection/freeswitch_spec.rb
+++ b/spec/punchblock/connection/freeswitch_spec.rb
@@ -33,6 +33,7 @@ module Punchblock
         it 'starts a RubyFS stream' do
           # subject.should_receive(:new_fs_stream).once.with('127.0.0.1', 8021, 'test').and_return mock_stream
           subject.stream.should_receive(:run).once
+          subject.should_receive(:handle_event).with(an_instance_of(Connection::Disconnected))
           lambda { subject.run }.should raise_error(DisconnectedError)
         end
       end


### PR DESCRIPTION
Up to now we can listen for Punchblock::Connection::Connected events, but I needed to know when Punchblock loses connection to the FS Event Socket. I added that event in a similar fashion as Connected event works.
