### PR TITLE
Component registry keys

### DIFF
--- a/lib/punchblock/client.rb
+++ b/lib/punchblock/client.rb
@@ -38,8 +38,8 @@ module Punchblock
       component_registry << component
     end
 
-    def find_component_by_id(component_id)
-      component_registry.find_by_id component_id
+    def find_component_by_key(key)
+      component_registry.find_by_key key
     end
 
     def delete_component_registration(component)

--- a/lib/punchblock/client/component_registry.rb
+++ b/lib/punchblock/client/component_registry.rb
@@ -10,13 +10,13 @@ module Punchblock
 
       def <<(component)
         @mutex.synchronize do
-          @components[component.component_id] = component
+          @components[component.key] = component
         end
       end
 
-      def find_by_id(component_id)
+      def find_by_key(key)
         @mutex.synchronize do
-          @components[component_id]
+          @components[key]
         end
       end
 

--- a/lib/punchblock/rayo_node.rb
+++ b/lib/punchblock/rayo_node.rb
@@ -85,8 +85,12 @@ module Punchblock
     # @return [RayoNode] the original command issued that lead to this event
     #
     def source
-      @source ||= client.find_component_by_id component_id if client && component_id
+      @source ||= client.find_component_by_key key if client && component_id
       @source ||= original_component
+    end
+
+    def key
+      "#{try(:component_id)}#{try(:target_call_id)}"
     end
 
     def rayo_attributes

--- a/spec/punchblock/client/component_registry_spec.rb
+++ b/spec/punchblock/client/component_registry_spec.rb
@@ -5,19 +5,19 @@ require 'spec_helper'
 module Punchblock
   class Client
     describe ComponentRegistry do
-      let(:component_id)  { 'abc123' }
-      let(:component)     { double 'Component', :component_id => component_id }
+      let(:component_key)  { 'abc123foo123' }
+      let(:component)      { double 'Component', :key => component_key }
 
       it 'should store components and allow lookup by ID' do
         subject << component
-        subject.find_by_id(component_id).should be component
+        subject.find_by_key(component_key).should be component
       end
 
       it 'should allow deletion of components' do
         subject << component
-        subject.find_by_id(component_id).should be component
+        subject.find_by_key(component_key).should be component
         subject.delete component
-        subject.find_by_id(component_id).should be_nil
+        subject.find_by_key(component_key).should be_nil
       end
     end
   end

--- a/spec/punchblock/client_spec.rb
+++ b/spec/punchblock/client_spec.rb
@@ -13,8 +13,9 @@ module Punchblock
 
     let(:call_id)         { 'abc123' }
     let(:mock_event)      { double('Event').as_null_object }
-    let(:component_id)    { 'abc123' }
-    let(:mock_component)  { double 'Component', :component_id => component_id }
+    let(:component_id)    { 'foo456' }
+    let(:component_key)   { 'foo456abc123'}
+    let(:mock_component)  { double 'Component', :component_id => component_id, key: component_key }
     let(:mock_command)    { double 'Command' }
 
     describe '#run' do
@@ -77,7 +78,7 @@ module Punchblock
 
     it 'should be able to register and retrieve components' do
       subject.register_component mock_component
-      subject.find_component_by_id(component_id).should be mock_component
+      subject.find_component_by_key(component_key).should be mock_component
     end
 
     describe '#execute_command' do

--- a/spec/punchblock/component/component_node_spec.rb
+++ b/spec/punchblock/component/component_node_spec.rb
@@ -80,7 +80,7 @@ module Punchblock
         it "should set the component ID from the ref" do
           subject.response = ref
           subject.component_id.should be == component_id
-          subject.client.find_component_by_id(component_id).should be subject
+          subject.client.find_component_by_key(component_id).should be subject
         end
       end
 
@@ -89,7 +89,7 @@ module Punchblock
           subject.request!
           subject.client = Client.new
           subject.response = Ref.new uri: 'abc'
-          subject.client.find_component_by_id('abc').should be subject
+          subject.client.find_component_by_key('abc').should be subject
         end
 
         it "should set the command to executing status" do
@@ -105,7 +105,7 @@ module Punchblock
 
         it "should remove the component from the registry" do
           subject.complete_event = :foo
-          subject.client.find_component_by_id('abc').should be_nil
+          subject.client.find_component_by_key('abc').should be_nil
         end
       end
     end # ComponentNode


### PR DESCRIPTION
I was running into issues where defining an Input component on multiple
legs of a call was resulting in the component on the b-leg overwriting
the one on the a-leg in the registry, messing up the event handling.

This may not be the best way to handle this, but it seems to work so
far..
