### PR TITLE
Start beep on freeswitch

### DIFF
--- a/lib/punchblock/translator/freeswitch/component/record.rb
+++ b/lib/punchblock/translator/freeswitch/component/record.rb
@@ -16,7 +16,6 @@ module Punchblock
             initial_timeout = @component_node.initial_timeout || -1
             final_timeout = @component_node.final_timeout || -1
 
-            raise OptionError, 'A start-beep value of true is unsupported.' if @component_node.start_beep
             raise OptionError, 'A start-paused value of true is unsupported.' if @component_node.start_paused
             raise OptionError, 'A max-duration value that is negative (and not -1) is invalid.' unless max_duration >= -1
 
@@ -40,6 +39,7 @@ module Punchblock
             setvar :RECORD_INITIAL_TIMEOUT_MS, initial_timeout > -1 ? initial_timeout : 0
             setvar :RECORD_FINAL_TIMEOUT_MS, final_timeout > -1 ? final_timeout : 0
 
+            call.application 'playback', "tone_stream://%(250,0,1000)" if @component_node.start_beep
             call.uuid_foo :record, record_args.join(' ')
             send_ref
           rescue OptionError => e

--- a/spec/punchblock/translator/freeswitch/component/record_spec.rb
+++ b/spec/punchblock/translator/freeswitch/component/record_spec.rb
@@ -220,10 +220,9 @@ module Punchblock
                 let(:command_options) { { :start_beep => true } }
 
                 it "should return an error and not execute any actions" do
-                  mock_call.should_receive(:uuid_foo).never
+                  mock_call.should_receive(:uuid_foo).once.with(:record, /.wav$/)
                   subject.execute
-                  error = ProtocolError.new.setup 'option error', 'A start-beep value of true is unsupported.'
-                  original_command.response(0.1).should be == error
+                  original_command.response(0.1).should be_a Ref
                 end
               end
             end


### PR DESCRIPTION
As mentioned in #154, support for start_beep is missing on Freeswitch platform.

PS: Recreated pull-request on fresh branch, and added missing specs.
