### PR TITLE
[BUGFIX] Register/lookup components by their full URI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [develop](https://github.com/adhearsion/punchblock)
   * Feature: Support RubySpeech builtin grammars on Asterisk and FreeSWITCH
   * Bugfix: Reject commands against components which have finished on Asterisk, and garbage collect them
+  * Bugfix: Register/lookup components by their full URI rather than component ID since the component ID may only be unique per call
 
 # [v2.0.1](https://github.com/adhearsion/punchblock/compare/v2.0.0...v2.0.1) - [2013-09-17](https://rubygems.org/gems/punchblock/versions/2.0.1)
   * Bugfix: Allow audio file URIs with file extensions on Asterisk

--- a/lib/punchblock/client.rb
+++ b/lib/punchblock/client.rb
@@ -38,8 +38,8 @@ module Punchblock
       component_registry << component
     end
 
-    def find_component_by_id(component_id)
-      component_registry.find_by_id component_id
+    def find_component_by_uri(uri)
+      component_registry.find_by_uri uri
     end
 
     def delete_component_registration(component)

--- a/lib/punchblock/client/component_registry.rb
+++ b/lib/punchblock/client/component_registry.rb
@@ -10,20 +10,20 @@ module Punchblock
 
       def <<(component)
         @mutex.synchronize do
-          @components[component.component_id] = component
+          @components[component.uri] = component
         end
       end
 
-      def find_by_id(component_id)
+      def find_by_uri(uri)
         @mutex.synchronize do
-          @components[component_id]
+          @components[uri]
         end
       end
 
       def delete(component)
         @mutex.synchronize do
-          id = @components.key component
-          @components.delete id
+          uri = @components.key component
+          @components.delete uri
         end
       end
     end

--- a/lib/punchblock/component/component_node.rb
+++ b/lib/punchblock/component/component_node.rb
@@ -5,6 +5,8 @@ module Punchblock
     class ComponentNode < CommandNode
       include HasGuardedHandlers
 
+      attribute :uri
+
       def initialize(*args)
         super
         @complete_event_resource = FutureResource.new
@@ -38,6 +40,7 @@ module Punchblock
       def response=(other)
         if other.is_a?(Ref)
           @component_id = other.component_id
+          @uri = other.uri.to_s
           client.register_component self if client
         end
         super

--- a/spec/punchblock/client/component_registry_spec.rb
+++ b/spec/punchblock/client/component_registry_spec.rb
@@ -5,19 +5,19 @@ require 'spec_helper'
 module Punchblock
   class Client
     describe ComponentRegistry do
-      let(:component_id)  { 'abc123' }
-      let(:component)     { double 'Component', :component_id => component_id }
+      let(:uri)       { 'abc123' }
+      let(:component) { double 'Component', uri: uri }
 
       it 'should store components and allow lookup by ID' do
         subject << component
-        subject.find_by_id(component_id).should be component
+        subject.find_by_uri(uri).should be component
       end
 
       it 'should allow deletion of components' do
         subject << component
-        subject.find_by_id(component_id).should be component
+        subject.find_by_uri(uri).should be component
         subject.delete component
-        subject.find_by_id(component_id).should be_nil
+        subject.find_by_uri(uri).should be_nil
       end
     end
   end

--- a/spec/punchblock/client_spec.rb
+++ b/spec/punchblock/client_spec.rb
@@ -14,7 +14,8 @@ module Punchblock
     let(:call_id)         { 'abc123' }
     let(:mock_event)      { double('Event').as_null_object }
     let(:component_id)    { 'abc123' }
-    let(:mock_component)  { double 'Component', :component_id => component_id }
+    let(:component_uri)   { 'callid@server/abc123' }
+    let(:mock_component)  { double 'Component', uri: component_uri }
     let(:mock_command)    { double 'Command' }
 
     describe '#run' do
@@ -77,7 +78,7 @@ module Punchblock
 
     it 'should be able to register and retrieve components' do
       subject.register_component mock_component
-      subject.find_component_by_id(component_id).should be mock_component
+      subject.find_component_by_uri(component_uri).should be mock_component
     end
 
     describe '#execute_command' do

--- a/spec/punchblock/component/component_node_spec.rb
+++ b/spec/punchblock/component/component_node_spec.rb
@@ -71,16 +71,17 @@ module Punchblock
           subject.client = Client.new
         end
 
-        let(:component_id) { 'abc123' }
+        let(:uri) { 'xmpp:callid@server/abc123' }
 
         let :ref do
-          Ref.new uri: component_id
+          Ref.new uri: uri
         end
 
         it "should set the component ID from the ref" do
           subject.response = ref
-          subject.component_id.should be == component_id
-          subject.client.find_component_by_id(component_id).should be subject
+          subject.component_id.should be == 'abc123'
+          subject.uri.should be == uri
+          subject.client.find_component_by_uri(uri).should be subject
         end
       end
 
@@ -89,7 +90,7 @@ module Punchblock
           subject.request!
           subject.client = Client.new
           subject.response = Ref.new uri: 'abc'
-          subject.client.find_component_by_id('abc').should be subject
+          subject.client.find_component_by_uri('abc').should be subject
         end
 
         it "should set the command to executing status" do
@@ -105,7 +106,7 @@ module Punchblock
 
         it "should remove the component from the registry" do
           subject.complete_event = :foo
-          subject.client.find_component_by_id('abc').should be_nil
+          subject.client.find_component_by_uri('abc').should be_nil
         end
       end
     end # ComponentNode


### PR DESCRIPTION
Rather than component ID since the component ID may only be unique per call. Fixes #177. @justinaiken: Thoughts?
