### PR TITLE
Add a few asterisk Bridge params to #join

### DIFF
--- a/lib/punchblock/command/join.rb
+++ b/lib/punchblock/command/join.rb
@@ -14,6 +14,18 @@ module Punchblock
       # @return [String] the mixer name to join
       attribute :mixer_name
 
+      # @return [Boolean] Whether to beep when joined
+      attribute :courtesy_tone, Boolean
+
+      # @return [Symbol] Which direction has the options to press '*' to hangup the call
+      attribute :hangup_power, Symbol
+      def hangup_power=(other)
+        if other && !VALID_DIRECTIONS.include?(other.to_sym)
+          raise ArgumentError, "Invalid Direction (#{other.inspect}), use: #{VALID_DIRECTIONS*' '}"
+        end
+        super
+      end
+
       # @param [#to_sym] other the direction in which media should flow. Can be :duplex, :recv or :send
       attribute :direction, Symbol
       def direction=(other)

--- a/lib/punchblock/translator/asterisk/call.rb
+++ b/lib/punchblock/translator/asterisk/call.rb
@@ -188,7 +188,7 @@ module Punchblock
           when Command::Join
             other_call = translator.call_with_id command.call_uri
             @pending_joins[other_call.channel] = command
-            execute_agi_command 'EXEC Bridge', other_call.channel
+            execute_agi_command 'EXEC Bridge', "#{other_call.channel},#{options_for_join(command)}"
           when Command::Unjoin
             other_call = translator.call_with_id command.call_uri
             redirect_back other_call
@@ -355,6 +355,14 @@ module Punchblock
           variables.inject([]) do |a, (k, v)|
             a << "#{k}=#{v}"
           end.join(',')
+        end
+
+        def options_for_join(command)
+          "".tap do |options|
+            options << "H"  if command.hangup_power == :send || command.hangup_power == :duplex
+            options << "h"  if command.hangup_power == :recv || command.hangup_power == :duplex
+            options << "p"  if command.courtesy_tone
+          end
         end
       end
     end


### PR DESCRIPTION
So here's a few params needed to be able to use `#join` in an Asterisk project I'm using (and some others that might be useful for others??)...
- [x] p - Play a courtesy tone to channel.
- [ ] F - When the bridger hangs up, transfer the bridged party to the next priority ofthe current extension and start execution at that location, or go to the next context/exten/priority specified 
- [x] h - Allow the called party to hang up by sending the \* DTMF digit.
- [x] H - Allow the calling party to hang up by pressing the \* DTMF digit.
- [ ] k - Allow the called party to enable parking of the call by sending the DTMF sequence defined for call parking in features.conf.
- [ ] K - Allow the calling party to enable parking of the call by sending the DTMF sequence defined for call parking in features.conf.
- [ ] L(xyz) - Limit the call to x ms. Play a warning when y ms are left. Repeat the warning every z ms. 
- [ ] S(error) - Hang up the call after x seconds after the called party has answered the call.
- [ ] t - Allow the called party to transfer the calling party by sending the DTMF sequence defined in features.conf.
- [ ] T - Allow the calling party to transfer the called party by sending the DTMF sequence defined in features.conf.
- [ ] w - Allow the called party to enable recording of the call by sending the DTMF sequence defined for one-touch recording in features.conf.
- [ ] W - Allow the calling party to enable recording of the call by sending the DTMF sequence defined for one-touch recording in features.conf.
- [ ] x - Cause the called party to be hung up after the bridge, instead of being restarted in the dialplan.

These are asterisk-only though. For now I've just stuck the ones I really needed in the `Join` Command as attributes, and added some code to the translator to populate the AGI command with them... 

Let me know if this approach works, and I'll add specs; if you see a better way let me know and I'm shift course...
