### PR TITLE
Reduce actor count for Asterisk Rayo translator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [develop](https://github.com/adhearsion/punchblock)
+  * Bugfix: Remove per-call/component actors from Asterisk translator for performance/stability super-charge
 
 # [v2.1.1](https://github.com/adhearsion/punchblock/compare/v2.1.0...v2.1.1) - [2013-12-19](https://rubygems.org/gems/punchblock/versions/2.1.1)
   * Bugfix: Allow sending string SSML docs via Rayo

--- a/lib/punchblock/connection/asterisk.rb
+++ b/lib/punchblock/connection/asterisk.rb
@@ -21,7 +21,7 @@ module Punchblock
       end
 
       def stop
-        translator.async.shutdown
+        translator.terminate
         ami_client.terminate
       end
 

--- a/lib/punchblock/translator/asterisk.rb
+++ b/lib/punchblock/translator/asterisk.rb
@@ -59,11 +59,6 @@ module Punchblock
         @components[component_id]
       end
 
-      def shutdown
-        @calls.values.each { |call| call.async.shutdown }
-        terminate
-      end
-
       def handle_ami_event(event)
         return unless event.is_a? RubyAMI::Event
 
@@ -81,7 +76,6 @@ module Punchblock
           handle_pb_event Event::Asterisk::AMI::Event.new(name: event.name, headers: event.headers)
         end
       end
-      exclusive :handle_ami_event
 
       def handle_pb_event(event)
         connection.handle_event event
@@ -104,7 +98,11 @@ module Punchblock
 
       def execute_call_command(command)
         if call = call_with_id(command.target_call_id)
-          call.async.execute_command command
+          begin
+            call.execute_command command
+          rescue => e
+            deregister_call call.id, call.channel
+          end
         else
           command.response = ProtocolError.new.setup :item_not_found, "Could not find a call with ID #{command.target_call_id}", command.target_call_id
         end
@@ -112,7 +110,7 @@ module Punchblock
 
       def execute_component_command(command)
         if (component = component_with_id(command.component_id))
-          component.async.execute_command command
+          component.execute_command command
         else
           command.response = ProtocolError.new.setup :item_not_found, "Could not find a component with ID #{command.component_id}", command.target_call_id, command.component_id
         end
@@ -123,11 +121,11 @@ module Punchblock
         when Punchblock::Component::Asterisk::AMI::Action
           component = Component::Asterisk::AMIAction.new command, current_actor, ami_client
           register_component component
-          component.async.execute
+          component.execute
         when Punchblock::Command::Dial
-          call = Call.new_link command.to, current_actor, ami_client, connection
+          call = Call.new command.to, current_actor, ami_client, connection
           register_call call
-          call.async.dial command
+          call.dial command
         else
           command.response = ProtocolError.new.setup 'command-not-acceptable', "Did not understand command"
         end
@@ -182,7 +180,7 @@ module Punchblock
         if !calls_for_event.empty?
           calls_for_event.each_pair do |channel, call|
             next if channel.bridged? && !EVENTS_ALLOWED_BRIDGED.include?(event.name)
-            call.async.process_ami_event event
+            call.process_ami_event event
           end
         elsif event.name == "AsyncAGI" && event['SubEvent'] == "Start"
           handle_async_agi_start_event event
@@ -204,9 +202,9 @@ module Punchblock
 
         return if env[:agi_extension] == 'h' || env[:agi_type] == 'Kill'
 
-        call = Call.new_link event['Channel'], current_actor, ami_client, connection, env
+        call = Call.new event['Channel'], current_actor, ami_client, connection, env
         register_call call
-        call.async.send_offer
+        call.send_offer
       end
     end
   end

--- a/lib/punchblock/translator/asterisk/component.rb
+++ b/lib/punchblock/translator/asterisk/component.rb
@@ -17,14 +17,11 @@ module Punchblock
         autoload :StopByRedirect
 
         class Component
-          include Celluloid
-          include DeadActorSafety
-
           attr_reader :id, :call, :call_id
 
           def initialize(component_node, call = nil)
             @component_node, @call = component_node, call
-            @call_id = safe_from_dead_actors { call.id } if call
+            @call_id = call.id if call
             @id = Punchblock.new_uuid
             @complete = false
             setup
@@ -37,19 +34,19 @@ module Punchblock
             command.response = ProtocolError.new.setup 'command-not-acceptable', "Did not understand command for component #{id}", call_id, id
           end
 
-          def send_complete_event(reason, recording = nil, should_terminate = true)
+          def send_complete_event(reason, recording = nil)
             return if @complete
             @complete = true
             event = Punchblock::Event::Complete.new reason: reason, recording: recording
             send_event event
-            terminate if should_terminate
+            call.deregister_component id if call
           end
 
           def send_event(event)
             event.component_id    = id
             event.target_call_id  = call_id
             event.source_uri      = id
-            safe_from_dead_actors { translator.handle_pb_event event }
+            translator.handle_pb_event event
           end
 
           def logger_id

--- a/lib/punchblock/translator/asterisk/component/asterisk/agi_command.rb
+++ b/lib/punchblock/translator/asterisk/component/asterisk/agi_command.rb
@@ -15,20 +15,16 @@ module Punchblock
               send_ref
             rescue RubyAMI::Error
               set_node_response false
-              terminate
             rescue ChannelGoneError
               set_node_response ProtocolError.new.setup(:item_not_found, "Could not find a call with ID #{call_id}", call_id)
-              terminate
             end
-            exclusive :execute
 
             def handle_ami_event(event)
               if event.name == 'AsyncAGI' && event['SubEvent'] == 'Exec'
-                send_complete_event success_reason(event), nil, false
+                send_complete_event success_reason(event)
                 if @component_node.name == 'ASYNCAGI BREAK' && @call.channel_var('PUNCHBLOCK_END_ON_ASYNCAGI_BREAK')
                   @call.handle_hangup_event
                 end
-                terminate
               end
             end
 

--- a/lib/punchblock/translator/asterisk/component/composed_prompt.rb
+++ b/lib/punchblock/translator/asterisk/component/composed_prompt.rb
@@ -15,9 +15,9 @@ module Punchblock
 
             @output_incomplete = true
 
-            output_component = Output.new_link(output_command, @call)
+            output_component = Output.new(output_command, @call)
             call.register_component output_component
-            fut = output_component.future.execute
+            fut = Thread.new { output_component.execute }
 
             case output_command.response
             when Ref
@@ -41,7 +41,7 @@ module Punchblock
 
           def process_dtmf(digit)
             if @component_node.barge_in && @output_incomplete
-              call.async.redirect_back
+              call.redirect_back
               @barged = true
             end
             super
@@ -58,14 +58,13 @@ module Punchblock
           end
 
           def register_dtmf_event_handler
-            component = current_actor
             @dtmf_handler_id = call.register_handler :ami, :name => 'DTMF', [:[], 'End'] => 'Yes' do |event|
-              component.process_dtmf event['Digit']
+              process_dtmf event['Digit']
             end
           end
 
           def unregister_dtmf_event_handler
-            call.async.unregister_handler :ami, @dtmf_handler_id if instance_variable_defined?(:@dtmf_handler_id)
+            call.unregister_handler :ami, @dtmf_handler_id if instance_variable_defined?(:@dtmf_handler_id)
           end
         end
       end

--- a/lib/punchblock/translator/asterisk/component/input.rb
+++ b/lib/punchblock/translator/asterisk/component/input.rb
@@ -17,14 +17,13 @@ module Punchblock
           private
 
           def register_dtmf_event_handler
-            component = current_actor
             call.register_handler :ami, :name => 'DTMF', [:[], 'End'] => 'Yes' do |event|
-              component.process_dtmf event['Digit']
+              process_dtmf event['Digit']
             end
           end
 
           def unregister_dtmf_event_handler
-            call.async.unregister_handler :ami, @dtmf_handler_id if instance_variable_defined?(:@dtmf_handler_id)
+            call.unregister_handler :ami, @dtmf_handler_id if instance_variable_defined?(:@dtmf_handler_id)
           end
         end
       end

--- a/lib/punchblock/translator/asterisk/component/output.rb
+++ b/lib/punchblock/translator/asterisk/component/output.rb
@@ -42,9 +42,8 @@ module Punchblock
               @call.send_progress if early
 
               if interrupt
-                output_component = current_actor
                 call.register_handler :ami, :name => 'DTMF', [:[], 'End'] => 'Yes' do |event|
-                  output_component.stop_by_redirect finish_reason
+                  stop_by_redirect finish_reason
                 end
               end
 

--- a/lib/punchblock/translator/asterisk/component/record.rb
+++ b/lib/punchblock/translator/asterisk/component/record.rb
@@ -22,9 +22,8 @@ module Punchblock
 
             @format = @component_node.format || 'wav'
 
-            component = current_actor
             call.register_tmp_handler :ami, :name => 'MonitorStop' do |event|
-              component.finished
+              finished
             end
 
             if @component_node.start_beep
@@ -33,7 +32,7 @@ module Punchblock
 
             ami_client.send_action 'Monitor', 'Channel' => call.channel, 'File' => filename, 'Format' => @format, 'Mix' => true
             unless max_duration == -1
-              after max_duration/1000 do
+              call.after max_duration/1000 do
                 ami_client.send_action 'StopMonitor', 'Channel' => call.channel
               end
             end

--- a/lib/punchblock/translator/asterisk/component/stop_by_redirect.rb
+++ b/lib/punchblock/translator/asterisk/component/stop_by_redirect.rb
@@ -18,11 +18,10 @@ module Punchblock
           end
 
           def stop_by_redirect(complete_reason)
-            component_actor = current_actor
             call.register_handler :ami, lambda { |e| e['SubEvent'] == 'Start' }, :name => 'AsyncAGI' do |event|
-              component_actor.async.send_complete_event complete_reason
+              send_complete_event complete_reason
             end
-            call.async.redirect_back
+            call.redirect_back
           end
         end
       end

--- a/lib/punchblock/translator/dtmf_recognizer.rb
+++ b/lib/punchblock/translator/dtmf_recognizer.rb
@@ -23,6 +23,8 @@ module Punchblock
         end
       end
 
+      include Celluloid
+
       def initialize(responder, grammar, initial_timeout = nil, inter_digit_timeout = nil, terminator = nil)
         @responder = responder
         self.initial_timeout = initial_timeout || -1
@@ -66,10 +68,6 @@ module Punchblock
 
       def get_match
         @matcher.match @buffer.dup
-      end
-
-      def after(*args, &block)
-        @responder.after *args, &block
       end
 
       def initial_timeout=(other)

--- a/spec/punchblock/connection/asterisk_spec.rb
+++ b/spec/punchblock/connection/asterisk_spec.rb
@@ -60,7 +60,7 @@ module Punchblock
         end
 
         it 'shuts down the translator' do
-          subject.translator.async.should_receive(:shutdown).once
+          subject.translator.should_receive(:terminate).once
           subject.stop
         end
       end

--- a/spec/punchblock/translator/asterisk/call_spec.rb
+++ b/spec/punchblock/translator/asterisk/call_spec.rb
@@ -69,14 +69,6 @@ module Punchblock
 
         before { translator.stub :handle_pb_event }
 
-        describe '#shutdown' do
-          it 'should terminate the actor' do
-            subject.shutdown
-            sleep 0.5
-            subject.should_not be_alive
-          end
-        end
-
         describe '#register_component' do
           it 'should make the component accessible by ID' do
             component_id = 'abc123'
@@ -123,15 +115,15 @@ module Punchblock
         describe '#send_progress' do
           context "with a call that is already answered" do
             it 'should not send the EXEC Progress command' do
-              subject.wrapped_object.should_receive(:'answered?').and_return true
-              subject.wrapped_object.should_receive(:execute_agi_command).with("EXEC Progress").never
+              subject.should_receive(:'answered?').and_return true
+              subject.should_receive(:execute_agi_command).with("EXEC Progress").never
               subject.send_progress
             end
           end
 
           context "with an unanswered call" do
             before do
-              subject.wrapped_object.should_receive(:'answered?').at_least(:once).and_return(false)
+              subject.should_receive(:'answered?').at_least(:once).and_return(false)
             end
 
             context "with a call that is outbound" do
@@ -143,7 +135,7 @@ module Punchblock
               end
 
               it 'should not send the EXEC Progress command' do
-                subject.wrapped_object.should_receive(:execute_agi_command).with("EXEC Progress").never
+                subject.should_receive(:execute_agi_command).with("EXEC Progress").never
                 subject.send_progress
               end
             end
@@ -154,12 +146,12 @@ module Punchblock
               end
 
               it 'should send the EXEC Progress command to a call that is inbound and not answered' do
-                subject.wrapped_object.should_receive(:execute_agi_command).with("EXEC Progress").and_return code: 200, result: 0
+                subject.should_receive(:execute_agi_command).with("EXEC Progress").and_return code: 200, result: 0
                 subject.send_progress
               end
 
               it 'should send the EXEC Progress command only once if called twice' do
-                subject.wrapped_object.should_receive(:execute_agi_command).with("EXEC Progress").once.and_return code: 200, result: 0
+                subject.should_receive(:execute_agi_command).with("EXEC Progress").once.and_return code: 200, result: 0
                 subject.send_progress
                 subject.send_progress
               end
@@ -276,7 +268,7 @@ module Punchblock
             subject.dial dial_command
             accept_command = Command::Accept.new
             accept_command.request!
-            subject.wrapped_object.should_receive(:execute_agi_command).never
+            subject.should_receive(:execute_agi_command).never
             subject.execute_command accept_command
             accept_command.response(0.5).should be true
           end
@@ -296,13 +288,6 @@ module Punchblock
 
             let(:cause)     { '16' }
             let(:cause_txt) { 'Normal Clearing' }
-
-            it "should cause the actor to be terminated" do
-              translator.should_receive(:handle_pb_event).twice
-              subject.process_ami_event ami_event
-              Celluloid::Actor.join(subject, 1)
-              subject.should_not be_alive
-            end
 
             it "de-registers the call from the translator" do
               translator.stub :handle_pb_event
@@ -334,13 +319,7 @@ module Punchblock
               component = subject.execute_command comp_command
               comp_command.response(0.1).should be_a Ref
 
-              # Give ourselves time to get both hangup event and new component in mailbox before termination takes place
-              subject.wrapped_object.should_receive(:wait).and_return do
-                sleep 1
-              end
-              subject.async.wait
-
-              subject.async.process_ami_event ami_event
+              subject.process_ami_event ami_event
 
               comp_command = Punchblock::Component::Input.new :grammar => {:value => '<grammar root="foo"><rule id="foo"/></grammar>'}, :mode => :dtmf
               comp_command.request!
@@ -663,7 +642,7 @@ module Punchblock
               before do
                 translator.register_call other_call
                 command.request!
-                subject.wrapped_object.should_receive(:execute_agi_command).and_return code: 200
+                subject.should_receive(:execute_agi_command).and_return code: 200
                 subject.execute_command command
               end
 
@@ -877,7 +856,7 @@ module Punchblock
             let(:command) { Command::Accept.new }
 
             it "should send an EXEC RINGING AGI command and set the command's response" do
-              subject.wrapped_object.should_receive(:execute_agi_command).with('EXEC RINGING').and_return code: 200
+              subject.should_receive(:execute_agi_command).with('EXEC RINGING').and_return code: 200
               subject.execute_command command
               command.response(0.5).should be true
             end
@@ -886,7 +865,7 @@ module Punchblock
               let(:message) { 'Some error' }
               let(:error)   { RubyAMI::Error.new.tap { |e| e.message = message } }
 
-              before { subject.wrapped_object.should_receive(:execute_agi_command).and_raise error }
+              before { subject.should_receive(:execute_agi_command).and_raise error }
 
               it "should return an error with the message" do
                 subject.execute_command command
@@ -909,7 +888,7 @@ module Punchblock
 
             it "with a :busy reason should send an EXEC Busy AGI command and set the command's response" do
               command.reason = :busy
-              subject.wrapped_object.should_receive(:execute_agi_command).with('EXEC Busy').and_return code: 200
+              subject.should_receive(:execute_agi_command).with('EXEC Busy').and_return code: 200
               subject.execute_command command
               command.response(0.5).should be true
             end
@@ -923,7 +902,7 @@ module Punchblock
 
             it "with an :error reason should send an EXEC Congestion AGI command and set the command's response" do
               command.reason = :error
-              subject.wrapped_object.should_receive(:execute_agi_command).with('EXEC Congestion').and_return code: 200
+              subject.should_receive(:execute_agi_command).with('EXEC Congestion').and_return code: 200
               subject.execute_command command
               command.response(0.5).should be true
             end
@@ -932,7 +911,7 @@ module Punchblock
               let(:message) { 'Some error' }
               let(:error)   { RubyAMI::Error.new.tap { |e| e.message = message } }
 
-              before { subject.wrapped_object.should_receive(:execute_agi_command).and_raise error }
+              before { subject.should_receive(:execute_agi_command).and_raise error }
 
               it "should return an error with the message" do
                 subject.execute_command command
@@ -954,13 +933,13 @@ module Punchblock
             let(:command) { Command::Answer.new }
 
             it "should send an ANSWER AGI command and set the command's response" do
-              subject.wrapped_object.should_receive(:execute_agi_command).with('ANSWER').and_return code: 200
+              subject.should_receive(:execute_agi_command).with('ANSWER').and_return code: 200
               subject.execute_command command
               command.response(0.5).should be true
             end
 
             it "should be answered" do
-              subject.wrapped_object.should_receive(:execute_agi_command)
+              subject.should_receive(:execute_agi_command)
               subject.execute_command command
               subject.should be_answered
             end
@@ -969,7 +948,7 @@ module Punchblock
               let(:message) { 'Some error' }
               let(:error)   { RubyAMI::Error.new.tap { |e| e.message = message } }
 
-              before { subject.wrapped_object.should_receive(:execute_agi_command).and_raise error }
+              before { subject.should_receive(:execute_agi_command).and_raise error }
 
               it "should return an error with the message" do
                 subject.execute_command command
@@ -1048,7 +1027,7 @@ module Punchblock
             before { translator.should_receive(:call_with_id).with(other_call_id).and_return(other_call) }
 
             it "executes the proper dialplan Bridge application" do
-              subject.wrapped_object.should_receive(:execute_agi_command).with('EXEC Bridge', "#{other_channel},F(#{REDIRECT_CONTEXT},#{REDIRECT_EXTENSION},#{REDIRECT_PRIORITY})").and_return code: 200
+              subject.should_receive(:execute_agi_command).with('EXEC Bridge', "#{other_channel},F(#{REDIRECT_CONTEXT},#{REDIRECT_EXTENSION},#{REDIRECT_PRIORITY})").and_return code: 200
               subject.execute_command command
             end
 
@@ -1056,7 +1035,7 @@ module Punchblock
               let(:message) { 'Some error' }
               let(:error)   { RubyAMI::Error.new.tap { |e| e.message = message } }
 
-              before { subject.wrapped_object.should_receive(:execute_agi_command).and_raise error }
+              before { subject.should_receive(:execute_agi_command).and_raise error }
 
               it "should return an error with the message" do
                 subject.execute_command command
@@ -1162,11 +1141,10 @@ module Punchblock
               Punchblock::Component::Asterisk::AGI::Command.new :name => 'Answer'
             end
 
-            let(:mock_action) { Translator::Asterisk::Component::Asterisk::AGICommand.new(command, subject) }
-
             it 'should create an AGI command component actor and execute it asynchronously' do
-              Component::Asterisk::AGICommand.should_receive(:new_link).once.with(command, subject).and_return mock_action
-              mock_action.async.should_receive(:execute).once
+              mock_action = Translator::Asterisk::Component::Asterisk::AGICommand.new(command, subject)
+              Component::Asterisk::AGICommand.should_receive(:new).once.with(command, subject).and_return mock_action
+              mock_action.should_receive(:execute).once
               subject.execute_command command
             end
           end
@@ -1176,11 +1154,10 @@ module Punchblock
               Punchblock::Component::Output.new
             end
 
-            let(:mock_action) { Translator::Asterisk::Component::Output.new(command, subject) }
-
             it 'should create an Output component and execute it asynchronously' do
-              Component::Output.should_receive(:new_link).once.with(command, subject).and_return mock_action
-              mock_action.async.should_receive(:execute).once
+              mock_action = Translator::Asterisk::Component::Output.new(command, subject)
+              Component::Output.should_receive(:new).once.with(command, subject).and_return mock_action
+              mock_action.should_receive(:execute).once
               subject.execute_command command
             end
           end
@@ -1190,11 +1167,10 @@ module Punchblock
               Punchblock::Component::Input.new
             end
 
-            let(:mock_action) { Translator::Asterisk::Component::Input.new(command, subject) }
-
             it 'should create an Input component and execute it asynchronously' do
-              Component::Input.should_receive(:new_link).once.with(command, subject).and_return mock_action
-              mock_action.async.should_receive(:execute).once
+              mock_action = Translator::Asterisk::Component::Input.new(command, subject)
+              Component::Input.should_receive(:new).once.with(command, subject).and_return mock_action
+              mock_action.should_receive(:execute).once
               subject.execute_command command
             end
           end
@@ -1230,13 +1206,15 @@ module Punchblock
 
             let(:mock_action) { Translator::Asterisk::Component::MRCPPrompt.new(command, subject) }
 
+            before { mock_action}
+
             context "when the recognizer is unimrcp and the renderer is unimrcp" do
               let(:recognizer)  { :unimrcp }
               let(:renderer)    { :unimrcp }
 
               it 'should create an MRCPPrompt component and execute it asynchronously' do
-                Component::MRCPPrompt.should_receive(:new_link).once.with(command, subject).and_return mock_action
-                mock_action.async.should_receive(:execute).once
+                Component::MRCPPrompt.should_receive(:new).once.with(command, subject).and_return mock_action
+                mock_action.should_receive(:execute).once
                 subject.execute_command command
               end
             end
@@ -1246,8 +1224,8 @@ module Punchblock
               let(:renderer)    { :asterisk }
 
               it 'should create an MRCPPrompt component and execute it asynchronously' do
-                Component::MRCPNativePrompt.should_receive(:new_link).once.with(command, subject).and_return mock_action
-                mock_action.async.should_receive(:execute).once
+                Component::MRCPNativePrompt.should_receive(:new).once.with(command, subject).and_return mock_action
+                mock_action.should_receive(:execute).once
                 subject.execute_command command
               end
             end
@@ -1267,8 +1245,8 @@ module Punchblock
               let(:renderer)    { :unimrcp }
 
               it 'should create a ComposedPrompt component and execute it asynchronously' do
-                Component::ComposedPrompt.should_receive(:new_link).once.with(command, subject).and_return mock_action
-                mock_action.async.should_receive(:execute).once
+                Component::ComposedPrompt.should_receive(:new).once.with(command, subject).and_return mock_action
+                mock_action.should_receive(:execute).once
                 subject.execute_command command
               end
             end
@@ -1279,11 +1257,10 @@ module Punchblock
               Punchblock::Component::Record.new
             end
 
-            let(:mock_action) { Translator::Asterisk::Component::Record.new(command, subject) }
-
             it 'should create a Record component and execute it asynchronously' do
-              Component::Record.should_receive(:new_link).once.with(command, subject).and_return mock_action
-              mock_action.async.should_receive(:execute).once
+              mock_action = Translator::Asterisk::Component::Record.new(command, subject)
+              Component::Record.should_receive(:new).once.with(command, subject).and_return mock_action
+              mock_action.should_receive(:execute).once
               subject.execute_command command
             end
           end
@@ -1333,9 +1310,8 @@ module Punchblock
                 it 'sends an error in response to the command' do
                   component = subject.component_with_id comp_id
 
-                  component.terminate
-                  sleep 0.1
-                  component.should_not be_alive
+                  component.send_complete_event Punchblock::Component::Asterisk::AGI::Command::Complete.new
+
                   subject.component_with_id(comp_id).should be_nil
 
                   subsequent_command.request!
@@ -1345,25 +1321,6 @@ module Punchblock
               end
 
               context "by crashing" do
-                it 'sends an error in response to the command' do
-                  component = subject.component_with_id comp_id
-
-                  component.wrapped_object.define_singleton_method(:oops) do
-                    raise 'Woops, I died'
-                  end
-
-                  translator.should_receive(:handle_pb_event).once.with expected_event
-
-                  lambda { component.oops }.should raise_error(/Woops, I died/)
-                  sleep 0.1
-                  component.should_not be_alive
-                  subject.component_with_id(comp_id).should be_nil
-
-                  subsequent_command.request!
-                  subject.execute_command subsequent_command
-                  subsequent_command.response.should be == ProtocolError.new.setup(:item_not_found, "Could not find a component with ID #{comp_id} for call #{subject.id}", subject.id, comp_id)
-                end
-
                 context "when we dispatch the command to it" do
                   it 'sends an error in response to the command' do
                     component = subject.component_with_id comp_id
@@ -1465,7 +1422,9 @@ module Punchblock
               end
 
               it 'should return the result' do
-                fut = subject.future.execute_agi_command 'EXEC ANSWER'
+                fut = Celluloid::Future.new { subject.execute_agi_command 'EXEC ANSWER' }
+
+                sleep 0.25
 
                 subject.process_ami_event ami_event
 

--- a/spec/punchblock/translator/asterisk/component/asterisk/agi_command_spec.rb
+++ b/spec/punchblock/translator/asterisk/component/asterisk/agi_command_spec.rb
@@ -81,7 +81,6 @@ module Punchblock
                 it 'should send the component node false' do
                   subject.execute
                   original_command.response(1).should be_false
-                  subject.should_not be_alive
                 end
 
                 context "which is 'No such channel'" do
@@ -90,7 +89,6 @@ module Punchblock
                   it "should return an :item_not_found error for the command" do
                     subject.execute
                     original_command.response(0.5).should be == ProtocolError.new.setup(:item_not_found, "Could not find a call with ID #{mock_call.id}", mock_call.id)
-                    subject.should_not be_alive
                   end
                 end
 
@@ -100,7 +98,6 @@ module Punchblock
                   it "should return an :item_not_found error for the command" do
                     subject.execute
                     original_command.response(0.5).should be == ProtocolError.new.setup(:item_not_found, "Could not find a call with ID #{mock_call.id}", mock_call.id)
-                    subject.should_not be_alive
                   end
                 end
               end

--- a/spec/punchblock/translator/asterisk/component/asterisk/ami_action_spec.rb
+++ b/spec/punchblock/translator/asterisk/component/asterisk/ami_action_spec.rb
@@ -58,7 +58,7 @@ module Punchblock
               context 'for a non-causal action' do
                 it 'should send a complete event to the component node' do
                   ami_client.should_receive(:send_action).once.and_return response
-                  subject.wrapped_object.should_receive(:send_complete_event).once.with expected_complete_reason
+                  subject.should_receive(:send_complete_event).once.with expected_complete_reason
                   subject.execute
                 end
               end

--- a/spec/punchblock/translator/asterisk/component/composed_prompt_spec.rb
+++ b/spec/punchblock/translator/asterisk/component/composed_prompt_spec.rb
@@ -207,7 +207,7 @@ module Punchblock
               end
 
               it "sets the command response to true" do
-                call.async.should_receive(:redirect_back).once
+                call.should_receive(:redirect_back).once
                 subject.execute_command command
                 command.response(0.1).should be == true
               end
@@ -219,7 +219,7 @@ module Punchblock
                   source_uri: subject.id,
                   target_call_id: call.id
 
-                call.async.should_receive(:redirect_back)
+                call.should_receive(:redirect_back)
                 subject.execute_command command
                 original_command.should_not be_complete
                 call.process_ami_event ami_event

--- a/spec/punchblock/translator/asterisk/component/input_spec.rb
+++ b/spec/punchblock/translator/asterisk/component/input_spec.rb
@@ -96,7 +96,7 @@ module Punchblock
                 end
 
                 it "should not process further dtmf events" do
-                  subject.async.should_receive(:process_dtmf).never
+                  subject.should_receive(:process_dtmf).never
                   send_ami_events_for_dtmf 3
                 end
               end
@@ -266,7 +266,7 @@ module Punchblock
                   end
 
                   it "should not process further dtmf events" do
-                    subject.async.should_receive(:process_dtmf).never
+                    subject.should_receive(:process_dtmf).never
                     send_ami_events_for_dtmf 3
                   end
                 end
@@ -331,7 +331,7 @@ module Punchblock
                 let(:original_command_opts) { { :initial_timeout => -1 } }
 
                 it "should not start a timer" do
-                  subject.wrapped_object.should_receive(:begin_initial_timer).never
+                  subject.should_receive(:begin_initial_timer).never
                   subject.execute
                 end
               end
@@ -340,7 +340,7 @@ module Punchblock
                 let(:original_command_opts) { { :initial_timeout => nil } }
 
                 it "should not start a timer" do
-                  subject.wrapped_object.should_receive(:begin_initial_timer).never
+                  subject.should_receive(:begin_initial_timer).never
                   subject.execute
                 end
               end
@@ -450,7 +450,7 @@ module Punchblock
                 let(:original_command_opts) { { :inter_digit_timeout => -1 } }
 
                 it "should not start a timer" do
-                  subject.wrapped_object.should_receive(:begin_inter_digit_timer).never
+                  subject.should_receive(:begin_inter_digit_timer).never
                   subject.execute
                 end
               end
@@ -459,7 +459,7 @@ module Punchblock
                 let(:original_command_opts) { { :inter_digit_timeout => nil } }
 
                 it "should not start a timer" do
-                  subject.wrapped_object.should_receive(:begin_inter_digit_timer).never
+                  subject.should_receive(:begin_inter_digit_timer).never
                   subject.execute
                 end
               end

--- a/spec/punchblock/translator/asterisk/component/mrcp_native_prompt_spec.rb
+++ b/spec/punchblock/translator/asterisk/component/mrcp_native_prompt_spec.rb
@@ -623,13 +623,13 @@ module Punchblock
               end
 
               it "sets the command response to true" do
-                mock_call.async.should_receive(:redirect_back)
+                mock_call.should_receive(:redirect_back)
                 subject.execute_command command
                 command.response(0.1).should be == true
               end
 
               it "sends the correct complete event" do
-                mock_call.async.should_receive(:redirect_back)
+                mock_call.should_receive(:redirect_back)
                 subject.execute_command command
                 original_command.should_not be_complete
                 mock_call.process_ami_event ami_event
@@ -638,7 +638,7 @@ module Punchblock
               end
 
               it "redirects the call by unjoining it" do
-                mock_call.async.should_receive(:redirect_back)
+                mock_call.should_receive(:redirect_back)
                 subject.execute_command command
               end
             end

--- a/spec/punchblock/translator/asterisk/component/mrcp_prompt_spec.rb
+++ b/spec/punchblock/translator/asterisk/component/mrcp_prompt_spec.rb
@@ -617,13 +617,13 @@ module Punchblock
               end
 
               it "sets the command response to true" do
-                mock_call.async.should_receive(:redirect_back)
+                mock_call.should_receive(:redirect_back)
                 subject.execute_command command
                 command.response(0.1).should be == true
               end
 
               it "sends the correct complete event" do
-                mock_call.async.should_receive(:redirect_back)
+                mock_call.should_receive(:redirect_back)
                 subject.execute_command command
                 original_command.should_not be_complete
                 mock_call.process_ami_event ami_event
@@ -632,7 +632,7 @@ module Punchblock
               end
 
               it "redirects the call by unjoining it" do
-                mock_call.async.should_receive(:redirect_back)
+                mock_call.should_receive(:redirect_back)
                 subject.execute_command command
               end
             end

--- a/spec/punchblock/translator/asterisk/component/output_spec.rb
+++ b/spec/punchblock/translator/asterisk/component/output_spec.rb
@@ -804,7 +804,7 @@ module Punchblock
                     it "does not redirect the call" do
                       expect_answered
                       expect_playback
-                      mock_call.async.should_receive(:redirect_back).never
+                      mock_call.should_receive(:redirect_back).never
                       subject.execute
                       original_command.response(0.1).should be_a Ref
                       send_ami_events_for_dtmf 1
@@ -817,24 +817,24 @@ module Punchblock
                     before do
                       expect_answered
                       mock_call.should_receive(:execute_agi_command).once.with('EXEC Playback', audio_filename)
-                      subject.wrapped_object.should_receive(:send_finish).and_return nil
+                      subject.should_receive(:send_finish).and_return nil
                     end
 
                     context "when a DTMF digit is received" do
                       it "sends the correct complete event" do
-                        mock_call.async.should_receive :redirect_back
+                        mock_call.should_receive :redirect_back
                         subject.execute
                         original_command.response(0.1).should be_a Ref
                         original_command.should_not be_complete
                         send_ami_events_for_dtmf 1
-                        mock_call.async.process_ami_event ami_event
+                        mock_call.process_ami_event ami_event
                         sleep 0.2
                         original_command.should be_complete
                         reason.should be_a Punchblock::Component::Output::Complete::Finish
                       end
 
                       it "redirects the call back to async AGI" do
-                        mock_call.async.should_receive(:redirect_back).once
+                        mock_call.should_receive(:redirect_back).once
                         subject.execute
                         original_command.response(0.1).should be_a Ref
                         send_ami_events_for_dtmf 1
@@ -848,24 +848,24 @@ module Punchblock
                     before do
                       expect_answered
                       mock_call.should_receive(:execute_agi_command).once.with('EXEC Playback', audio_filename)
-                      subject.wrapped_object.should_receive(:send_finish).and_return nil
+                      subject.should_receive(:send_finish).and_return nil
                     end
 
                     context "when a DTMF digit is received" do
                       it "sends the correct complete event" do
-                        mock_call.async.should_receive :redirect_back
+                        mock_call.should_receive :redirect_back
                         subject.execute
                         original_command.response(0.1).should be_a Ref
                         original_command.should_not be_complete
                         send_ami_events_for_dtmf 1
-                        mock_call.async.process_ami_event ami_event
+                        mock_call.process_ami_event ami_event
                         sleep 0.2
                         original_command.should be_complete
                         reason.should be_a Punchblock::Component::Output::Complete::Finish
                       end
 
                       it "redirects the call back to async AGI" do
-                        mock_call.async.should_receive(:redirect_back).once
+                        mock_call.should_receive(:redirect_back).once
                         subject.execute
                         original_command.response(0.1).should be_a Ref
                         send_ami_events_for_dtmf 1
@@ -915,13 +915,13 @@ module Punchblock
               end
 
               it "sets the command response to true" do
-                mock_call.async.should_receive(:redirect_back)
+                mock_call.should_receive(:redirect_back)
                 subject.execute_command command
                 command.response(0.1).should be == true
               end
 
               it "sends the correct complete event" do
-                mock_call.async.should_receive(:redirect_back)
+                mock_call.should_receive(:redirect_back)
                 subject.execute_command command
                 original_command.should_not be_complete
                 mock_call.process_ami_event ami_event
@@ -930,7 +930,7 @@ module Punchblock
               end
 
               it "redirects the call by unjoining it" do
-                mock_call.async.should_receive(:redirect_back)
+                mock_call.should_receive(:redirect_back)
                 subject.execute_command command
               end
             end

--- a/spec/punchblock/translator/asterisk/component/stop_by_redirect_spec.rb
+++ b/spec/punchblock/translator/asterisk/component/stop_by_redirect_spec.rb
@@ -41,7 +41,7 @@ module Punchblock
               end
 
               it "sets the command response to true" do
-                mock_call.async.should_receive(:redirect_back)
+                mock_call.should_receive(:redirect_back)
                 mock_call.should_receive(:register_handler).with do |type, *guards|
                   type.should be == :ami
                   guards.should have(2).guards

--- a/spec/punchblock/translator/asterisk/component_spec.rb
+++ b/spec/punchblock/translator/asterisk/component_spec.rb
@@ -48,21 +48,14 @@ module Punchblock
             end
 
             it "should send a complete event with the specified reason" do
-              subject.wrapped_object.should_receive(:send_event).once.with expected_event
+              subject.should_receive(:send_event).once.with expected_event
               subject.send_complete_event reason
-            end
-
-            it "should cause the actor to be shut down" do
-              subject.wrapped_object.stub(:send_event).and_return true
-              subject.send_complete_event reason
-              sleep 0.2
-              subject.should_not be_alive
             end
           end
 
           describe "#call_ended" do
             it "should send a complete event with the call hangup reason" do
-              subject.wrapped_object.should_receive(:send_complete_event).once.with Punchblock::Event::Complete::Hangup.new
+              subject.should_receive(:send_complete_event).once.with Punchblock::Event::Complete::Hangup.new
               subject.call_ended
             end
           end

--- a/spec/punchblock/translator/asterisk_spec.rb
+++ b/spec/punchblock/translator/asterisk_spec.rb
@@ -18,21 +18,6 @@ module Punchblock
 
       after { translator.terminate if translator.alive? }
 
-      describe '#shutdown' do
-        it "instructs all calls to shutdown" do
-          call = Asterisk::Call.new 'foo', subject, ami_client, connection
-          call.async.should_receive(:shutdown).once
-          subject.register_call call
-          subject.shutdown
-        end
-
-        it "terminates the actor" do
-          subject.shutdown
-          sleep 0.2
-          subject.should_not be_alive
-        end
-      end
-
       describe '#execute_command' do
         describe 'with a call command' do
           let(:command) { Command::Answer.new }
@@ -136,78 +121,31 @@ module Punchblock
           end
 
           it 'sends the command to the call for execution' do
-            call.async.should_receive(:execute_command).once.with command
+            call.should_receive(:execute_command).once.with command
             subject.execute_call_command command
+          end
+
+          context 'when it raises' do
+            before do
+              call.should_receive(:execute_command).and_raise StandardError
+            end
+
+            let(:other_command) { Command::Answer.new target_call_id: call_id }
+
+            it 'sends an error in response to the command' do
+              subject.execute_call_command command
+
+              subject.call_with_id(call_id).should be_nil
+
+              other_command.request!
+              subject.execute_call_command other_command
+              other_command.response.should be == ProtocolError.new.setup(:item_not_found, "Could not find a call with ID #{call_id}", call_id)
+            end
           end
         end
 
         let :end_error_event do
           Punchblock::Event::End.new reason: :error, target_call_id: call_id
-        end
-
-        context "for an outgoing call which began executing but crashed" do
-          let(:dial_command) { Command::Dial.new :to => 'SIP/1234', :from => 'abc123' }
-
-          let(:call_id) { dial_command.response.call_id }
-
-          before do
-            subject.async.should_receive(:execute_global_command)
-            subject.execute_command dial_command
-          end
-
-          it 'sends an error in response to the command' do
-            call = subject.call_with_id call_id
-
-            call.wrapped_object.define_singleton_method(:oops) do
-              raise 'Woops, I died'
-            end
-
-            connection.should_receive(:handle_event).once.with end_error_event
-
-            lambda { call.oops }.should raise_error(/Woops, I died/)
-            sleep 0.1
-            call.should_not be_alive
-            subject.call_with_id(call_id).should be_nil
-
-            command.request!
-            subject.execute_call_command command
-            command.response.should be == ProtocolError.new.setup(:item_not_found, "Could not find a call with ID #{call_id}", call_id)
-          end
-        end
-
-        context "for an incoming call which began executing but crashed" do
-          let :ami_event do
-            RubyAMI::Event.new 'AsyncAGI',
-              'SubEvent' => "Start",
-              'Channel'  => "SIP/1234-00000000",
-              'Env'      => "agi_request%3A%20async%0Aagi_channel%3A%20SIP%2F1234-00000000%0Aagi_language%3A%20en%0Aagi_type%3A%20SIP%0Aagi_uniqueid%3A%201320835995.0%0Aagi_version%3A%201.8.4.1%0Aagi_callerid%3A%205678%0Aagi_calleridname%3A%20Jane%20Smith%0Aagi_callingpres%3A%200%0Aagi_callingani2%3A%200%0Aagi_callington%3A%200%0Aagi_callingtns%3A%200%0Aagi_dnid%3A%201000%0Aagi_rdnis%3A%20unknown%0Aagi_context%3A%20default%0Aagi_extension%3A%201000%0Aagi_priority%3A%201%0Aagi_enhanced%3A%200.0%0Aagi_accountcode%3A%20%0Aagi_threadid%3A%204366221312%0A%0A"
-          end
-
-          let(:call)    { subject.call_for_channel('SIP/1234-00000000') }
-          let(:call_id) { call.id }
-
-          before do
-            connection.stub :handle_event
-            subject.handle_ami_event ami_event
-            call_id
-          end
-
-          it 'sends an error in response to the command' do
-            call.wrapped_object.define_singleton_method(:oops) do
-              raise 'Woops, I died'
-            end
-
-            connection.should_receive(:handle_event).once.with end_error_event
-
-            lambda { call.oops }.should raise_error(/Woops, I died/)
-            sleep 0.1
-            call.should_not be_alive
-            subject.call_with_id(call_id).should be_nil
-
-            command.request!
-            subject.execute_call_command command
-            command.response.should be == ProtocolError.new.setup(:item_not_found, "Could not find a call with ID #{call_id}", call_id)
-          end
         end
 
         context "with an unknown call ID" do
@@ -236,7 +174,7 @@ module Punchblock
           end
 
           it 'sends the command to the component for execution' do
-            component.async.should_receive(:execute_command).once.with command
+            component.should_receive(:execute_command).once.with command
             subject.execute_component_command command
           end
         end
@@ -262,14 +200,14 @@ module Punchblock
 
           it 'should be able to look up the call by channel ID' do
             subject.execute_global_command command
-            call_actor = subject.call_for_channel('SIP/1234')
-            call_actor.wrapped_object.should be_a Asterisk::Call
+            call = subject.call_for_channel('SIP/1234')
+            call.should be_a Asterisk::Call
           end
 
           it 'should instruct the call to send a dial' do
             mock_call = double('Asterisk::Call').as_null_object
-            Asterisk::Call.should_receive(:new_link).once.and_return mock_call
-            mock_call.async.should_receive(:dial).once.with command
+            Asterisk::Call.should_receive(:new).once.and_return mock_call
+            mock_call.should_receive(:dial).once.with command
             subject.execute_global_command command
           end
         end
@@ -283,7 +221,7 @@ module Punchblock
 
           it 'should create a component actor and execute it asynchronously' do
             Asterisk::Component::Asterisk::AMIAction.should_receive(:new).once.with(command, subject, ami_client).and_return mock_action
-            mock_action.async.should_receive(:execute).once
+            mock_action.should_receive(:execute).once
             subject.execute_global_command command
           end
 
@@ -365,10 +303,10 @@ module Punchblock
 
           it 'should be able to look up the call by channel ID' do
             subject.handle_ami_event ami_event
-            call_actor = subject.call_for_channel('SIP/1234-00000000')
-            call_actor.should be_a Asterisk::Call
-            call_actor.agi_env.should be_a Hash
-            call_actor.agi_env.should be == {
+            call = subject.call_for_channel('SIP/1234-00000000')
+            call.should be_a Asterisk::Call
+            call.agi_env.should be_a Hash
+            call.agi_env.should be == {
               :agi_request      => 'async',
               :agi_channel      => 'SIP/1234-00000000',
               :agi_language     => 'en',
@@ -394,8 +332,8 @@ module Punchblock
 
           it 'should instruct the call to send an offer' do
             mock_call = double('Asterisk::Call').as_null_object
-            Asterisk::Call.should_receive(:new_link).once.and_return mock_call
-            mock_call.async.should_receive(:send_offer).once
+            Asterisk::Call.should_receive(:new).once.and_return mock_call
+            mock_call.should_receive(:send_offer).once
             subject.handle_ami_event ami_event
           end
 
@@ -407,7 +345,7 @@ module Punchblock
             end
 
             it "should not create a new call" do
-              Asterisk::Call.should_receive(:new_link).never
+              Asterisk::Call.should_receive(:new).never
               subject.handle_ami_event ami_event
             end
           end
@@ -523,7 +461,7 @@ module Punchblock
           end
 
           it 'sends the AMI event to the call and to the connection as a PB event' do
-            call.async.should_receive(:process_ami_event).once.with ami_event
+            call.should_receive(:process_ami_event).once.with ami_event
             subject.handle_ami_event ami_event
           end
 
@@ -544,8 +482,8 @@ module Punchblock
               before { subject.register_call call2 }
 
               it 'should send the event to both calls and to the connection once as a PB event' do
-                call.async.should_receive(:process_ami_event).once.with ami_event
-                call2.async.should_receive(:process_ami_event).once.with ami_event
+                call.should_receive(:process_ami_event).once.with ami_event
+                call2.should_receive(:process_ami_event).once.with ami_event
                 subject.handle_ami_event ami_event
               end
             end
@@ -578,12 +516,12 @@ module Punchblock
           end
 
           it 'sends the AMI event to the call and to the connection as a PB event if it is an allowed event' do
-            call.async.should_receive(:process_ami_event).once.with ami_event
+            call.should_receive(:process_ami_event).once.with ami_event
             subject.handle_ami_event ami_event
           end
 
           it 'does not send the AMI event to a bridged channel if it is not allowed' do
-            call.async.should_receive(:process_ami_event).never.with ami_event2
+            call.should_receive(:process_ami_event).never.with ami_event2
             subject.handle_ami_event ami_event2
           end
 


### PR DESCRIPTION
WIP

This keeps the number of actors fixed (at one, for the translator) rather than at least one actor per call, with extras for components.
- [x] - Remove Asterisk per-call actors
- [x] - Remove Asterisk per-component actors
- [x] - Fault tolerance per call / per component
