### PR TITLE
Track / expose mixer status

### DIFF
--- a/lib/punchblock/event.rb
+++ b/lib/punchblock/event.rb
@@ -17,4 +17,6 @@ end
   unjoined
   started_speaking
   stopped_speaking
+  mixer_created
+  mixer_destroyed
 }.each { |e| require "punchblock/event/#{e}"}

--- a/lib/punchblock/event/mixer_created.rb
+++ b/lib/punchblock/event/mixer_created.rb
@@ -1,0 +1,8 @@
+# encoding: utf-8
+
+module Punchblock
+  class Event
+    class MixerCreated < Event
+    end
+  end
+end

--- a/lib/punchblock/event/mixer_destroyed.rb
+++ b/lib/punchblock/event/mixer_destroyed.rb
@@ -1,0 +1,8 @@
+# encoding: utf-8
+
+module Punchblock
+  class Event
+    class MixerDestroyed < Event
+    end
+  end
+end

--- a/spec/punchblock/event/mixer_created_spec.rb
+++ b/spec/punchblock/event/mixer_created_spec.rb
@@ -1,0 +1,13 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+module Punchblock
+  class Event
+    describe MixerCreated do
+      subject { described_class.new target_mixer_name: 'foobar' }
+
+      its(:target_mixer_name) { should == 'foobar' }
+    end
+  end
+end

--- a/spec/punchblock/event/mixer_destroyed_spec.rb
+++ b/spec/punchblock/event/mixer_destroyed_spec.rb
@@ -1,0 +1,13 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+module Punchblock
+  class Event
+    describe MixerDestroyed do
+      subject { described_class.new target_mixer_name: 'foobar' }
+
+      its(:target_mixer_name) { should == 'foobar' }
+    end
+  end
+end


### PR DESCRIPTION
WIP. See https://github.com/adhearsion/adhearsion/issues/411

Todo:
- [ ] Watch for mixer CAPS in presence, record as a known mixer (see https://github.com/adhearsion/punchblock/blob/develop/lib/punchblock/connection/xmpp.rb#L131)
- [ ] Fire FS event when we first encounter a mixer
- [ ] Fire FS event and clear registration when we see a mixer go away
