### PR TITLE
[FEATURE] Implement a simple filter for AMI events -> Rayo events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [develop](https://github.com/adhearsion/punchblock)
+  * Feature: Implement a simple filter for AMI events -> Rayo events in `Punchblock::Translator::Asterisk.event_filter=`
   * Bugfix: Remove per-call/component actors from Asterisk translator for performance/stability super-charge
 
 # [v2.1.1](https://github.com/adhearsion/punchblock/compare/v2.1.0...v2.1.1) - [2013-12-19](https://rubygems.org/gems/punchblock/versions/2.1.1)

--- a/lib/punchblock/translator/asterisk/call.rb
+++ b/lib/punchblock/translator/asterisk/call.rb
@@ -107,7 +107,9 @@ module Punchblock
         end
 
         def process_ami_event(ami_event)
-          send_pb_event Event::Asterisk::AMI::Event.new(name: ami_event.name, headers: ami_event.headers)
+          if Asterisk.event_passes_filter?(ami_event)
+            send_pb_event Event::Asterisk::AMI::Event.new(name: ami_event.name, headers: ami_event.headers)
+          end
 
           case ami_event.name
           when 'Hangup'

--- a/spec/punchblock/translator/asterisk/call_spec.rb
+++ b/spec/punchblock/translator/asterisk/call_spec.rb
@@ -845,6 +845,15 @@ module Punchblock
             subject.process_ami_event ami_event
           end
 
+          context "when the event doesn't pass the filter" do
+            before { Asterisk.event_filter = ->(event) { false } }
+            after { Asterisk.event_filter = nil }
+
+            it 'does not send the AMI event to the connection as a PB event' do
+              translator.should_receive(:handle_pb_event).never
+              subject.process_ami_event ami_event
+            end
+          end
         end
 
         describe '#execute_command' do

--- a/spec/punchblock/translator/asterisk_spec.rb
+++ b/spec/punchblock/translator/asterisk_spec.rb
@@ -274,6 +274,16 @@ module Punchblock
           subject.handle_ami_event ami_event
         end
 
+        context "when the event doesn't pass the filter" do
+          before { described_class.event_filter = ->(event) { false } }
+          after { described_class.event_filter = nil }
+
+          it 'does not send the AMI event to the connection as a PB event' do
+            subject.connection.should_receive(:handle_event).never
+            subject.handle_ami_event ami_event
+          end
+        end
+
         context 'with something that is not a RubyAMI::Event' do
           it 'does not send anything to the connection' do
             subject.connection.should_receive(:handle_event).never


### PR DESCRIPTION
`Punchblock::Translator::Asterisk.event_filter=`

This potentially reduces the number of Rayo events Punchblock emits for each AMI event, while allowing control over desired events.

/cc @jaiken for review - does this suit your needs?
