### PR TITLE
Bump the min rspec development dependency to 2.13

### DIFF
--- a/punchblock.gemspec
+++ b/punchblock.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency %q<ruby_jid>, ["~> 1.0"]
 
   s.add_development_dependency %q<bundler>, ["~> 1.0"]
-  s.add_development_dependency %q<rspec>, ["~> 2.7"]
+  s.add_development_dependency %q<rspec>, ["~> 2.13"]
   s.add_development_dependency %q<ci_reporter>, ["~> 1.6"]
   s.add_development_dependency %q<yard>, ["~> 0.6"]
   s.add_development_dependency %q<rake>, [">= 0"]


### PR DESCRIPTION
The punchblock spec suite implicitly requires rspec 2.13 or higher.  Anything less, and you get unexpected errors.  This just formalizes the updated dependency requirement.

On rspec < 2.12, you'd get this before any tests ran at all:

$ cd punchblock
$ bundle exec rspec spec

``````
/Users/sgeorge/.rvm/gems/ruby-1.9.3-p545/gems/rspec-core-2.11.1/lib/rspec/core/configuration.rb:334:in `mock_with': RSpec::Core::MockFrameworkAdapter must respond to `configuration` so that mock_with can yield it. (RuntimeError)
  from /Users/sgeorge/Code/adhearsion/adhearsion-punchblock/spec/spec_helper.rb:19:in `block in <top (required)>'
  from /Users/sgeorge/.rvm/gems/ruby-1.9.3-p545/gems/rspec-core-2.11.1/lib/rspec/core.rb:92:in `configure'
  from /Users/sgeorge/Code/adhearsion/adhearsion-punchblock/spec/spec_helper.rb:15:in `<top (required)>'
  from /Users/sgeorge/Code/adhearsion/adhearsion-punchblock/spec/punchblock/client/component_registry_spec.rb:3:in `require'
  from /Users/sgeorge/Code/adhearsion/adhearsion-punchblock/spec/punchblock/client/component_registry_spec.rb:3:in `<top (required)>'
  from /Users/sgeorge/.rvm/gems/ruby-1.9.3-p545/gems/rspec-core-2.11.1/lib/rspec/core/configuration.rb:780:in `load'
  from /Users/sgeorge/.rvm/gems/ruby-1.9.3-p545/gems/rspec-core-2.11.1/lib/rspec/core/configuration.rb:780:in `block in load_spec_files'
  from /Users/sgeorge/.rvm/gems/ruby-1.9.3-p545/gems/rspec-core-2.11.1/lib/rspec/core/configuration.rb:780:in `map'
  from /Users/sgeorge/.rvm/gems/ruby-1.9.3-p545/gems/rspec-core-2.11.1/lib/rspec/core/configuration.rb:780:in `load_spec_files'
  from /Users/sgeorge/.rvm/gems/ruby-1.9.3-p545/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:22:in `run'
  from /Users/sgeorge/.rvm/gems/ruby-1.9.3-p545/gems/rspec-core-2.11.1/lib/rspec/core/runner.rb:69:in `run'
  from /Users/sgeorge/.rvm/gems/ruby-1.9.3-p545/gems/rspec-core-2.11.1/lib/rspec/core/runner.rb:8:in `block in autorun'```

Even more confusing on rspec == 2.12.0... you'd get several test failures.

2.13.0 seems to be the minimum version for tests to both run and pass.
``````
