### PR TITLE
Memory leak due to recent performance improvement 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [develop](https://github.com/adhearsion/punchblock)
+  * Bugfix: Ensure DTMF recognisers get shut down when finishing
 
 # [v2.5.0](https://github.com/adhearsion/punchblock/compare/v2.4.2...v2.5.0) - [2014-03-05](https://rubygems.org/gems/punchblock/versions/2.5.0)
   * Feature: Support language, sensitivity and minimum confidence on UniMRCP-based ASR on Asterisk

--- a/lib/punchblock/translator/dtmf_recognizer.rb
+++ b/lib/punchblock/translator/dtmf_recognizer.rb
@@ -122,6 +122,7 @@ module Punchblock
           @responder.send match_type
         end
         @finished = true
+        terminate
       end
     end
   end

--- a/spec/punchblock/translator/asterisk/component/input_spec.rb
+++ b/spec/punchblock/translator/asterisk/component/input_spec.rb
@@ -99,6 +99,10 @@ module Punchblock
                   subject.should_receive(:process_dtmf).never
                   send_ami_events_for_dtmf 3
                 end
+
+                it "should not leave the recognizer running" do
+                  Celluloid::Actor.all.map { |a| a.class }.should_not include(Punchblock::Translator::DTMFRecognizer)
+                end
               end
 
               context "when the match is invalid" do


### PR DESCRIPTION
### Overview
- Occurs with either :asterisk or :native_or_unimrcp output renderers.
- Requires that you are using the suggested adhearsion-asr gem
- Requires an `ask`.  A `say` will not produce the error.
- Does not require playing of any TTS or WAV in the #ask in order for the memory leak to grow.  Our ask command was:  `ask :limit 1`.
- Does not require that the SIPp load test send any DTMF input whatsoever in order for the memory leak to grow.
### Defect details
- Occurs under JRuby as well as C-Ruby.  Rubies and environments tested:
  - [JRuby 1.7.4 environment details](https://github.com/sfgeorge/punchblock-issue-memleak/blob/master/environments/jruby-1.7.4/README.md)
  - [CRuby 1.9.3 environment details](https://github.com/sfgeorge/punchblock-issue-memleak/blob/master/environments/ruby-1.9.3-p392/README.md)
- Breaking change: [Using git-bisect](https://mojolingo.com/blog/2013/using-git-bisect-to-troubleshoot-ruby-gems/), we were able to pin-point this to adhearsion/punchblock@f939eca  
- Latest version tested: Tested and confirmed to still be an issue in Punchblock 2.5.0
- Minimal reproducible example: See https://github.com/sfgeorge/punchblock-issue-memleak
### Contributors
- [Tony Castiglione](https://github.com/runningferret)
- [Stephen George](https://github.com/sfgeorge)
