### PR TITLE
[Feature] Add some logging when FutureResource::ResourceAlreadySetException

### DIFF
--- a/lib/punchblock/command_node.rb
+++ b/lib/punchblock/command_node.rb
@@ -37,6 +37,8 @@ module Punchblock
       e.message << " for command #{self}"
       raise e
     rescue FutureResource::ResourceAlreadySetException
+      pb_logger.warn "Rescuing a FutureResource::ResourceAlreadySetException!"
+      pb_logger.warn "Here is some information about me: #{self.inspect}"      
     end
   end # CommandNode
 end # Punchblock


### PR DESCRIPTION
Just for our own edification. The original is just a no-op, but we're concerned we might be missing important information.
