### PR TITLE
[Feature] Send recognition timeout to UniMRCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [develop](https://github.com/adhearsion/punchblock)
+  * Feature: Support recognition-timeout settings on UniMRCP-based ASR on Asterisk
 
 # [v2.5.3](https://github.com/adhearsion/punchblock/compare/v2.5.2...v2.5.3) - [2014-09-22](https://rubygems.org/gems/punchblock/versions/2.5.3)
   * Bugfix: Prevent Asterisk translator death due to dead DTMF recognizers ([#221](https://github.com/adhearsion/punchblock/pull/221), [adhearsion/adhearsion#479](https://github.com/adhearsion/adhearsion/issues/479))

--- a/lib/punchblock/component/input.rb
+++ b/lib/punchblock/component/input.rb
@@ -34,6 +34,9 @@ module Punchblock
       # @return [Integer] Indicates (in the case of DTMF input) the amount of time (in milliseconds) between input digits which may expire before a timeout is triggered.
       attribute :inter_digit_timeout, Integer
 
+      # @return [Integer] Indicates the amount of time during input that recognition will occur before a timeout is triggered.
+      attribute :recognition_timeout, Integer
+
       attribute :grammars, Array, default: []
       def grammars=(others)
         super others.map { |other| Grammar.new(other) }
@@ -65,7 +68,8 @@ module Punchblock
           'terminator' => terminator,
           'sensitivity' => sensitivity,
           'initial-timeout' => initial_timeout,
-          'inter-digit-timeout' => inter_digit_timeout
+          'inter-digit-timeout' => inter_digit_timeout,
+          'recognition-timeout' => recognition_timeout
         }
       end
 

--- a/lib/punchblock/translator/asterisk/component/mrcp_recog_prompt.rb
+++ b/lib/punchblock/translator/asterisk/component/mrcp_recog_prompt.rb
@@ -34,6 +34,7 @@ module Punchblock
 
             raise OptionError, "An initial-timeout value must be -1 or a positive integer." if @initial_timeout < -1
             raise OptionError, "An inter-digit-timeout value must be -1 or a positive integer." if @inter_digit_timeout < -1
+            raise OptionError, "A recognition-timeout value must be -1, 0, or a positive integer." if @recognition_timeout < -1
           end
 
           def execute_app(app, *args)
@@ -48,6 +49,7 @@ module Punchblock
               opts[:spl] = input_node.language if input_node.language
               opts[:ct] = input_node.min_confidence if input_node.min_confidence
               opts[:sl] = input_node.sensitivity if input_node.sensitivity
+              opts[:t]  = input_node.recognition_timeout if @recognition_timeout > -1
               yield opts
             end
           end
@@ -55,6 +57,7 @@ module Punchblock
           def setup_defaults
             @initial_timeout = input_node.initial_timeout || -1
             @inter_digit_timeout = input_node.inter_digit_timeout || -1
+            @recognition_timeout = input_node.recognition_timeout || -1
           end
 
           def grammars

--- a/spec/punchblock/component/input_spec.rb
+++ b/spec/punchblock/component/input_spec.rb
@@ -19,6 +19,7 @@ module Punchblock
                     :language             => 'en-US',
                     :initial_timeout      => 2000,
                     :inter_digit_timeout  => 2000,
+                    :recognition_timeout  => 0,
                     :sensitivity          => 0.5,
                     :min_confidence       => 0.5
         end
@@ -61,6 +62,11 @@ module Punchblock
         describe '#inter_digit_timeout' do
           subject { super().inter_digit_timeout }
           it { should be == 2000 }
+        end
+
+        describe '#recognition_timeout' do
+          subject { super().recognition_timeout }
+          it { should be == 0 }
         end
 
         describe '#sensitivity' do
@@ -118,6 +124,7 @@ module Punchblock
             expect(new_instance.language).to eq('en-US')
             expect(new_instance.initial_timeout).to eq(2000)
             expect(new_instance.inter_digit_timeout).to eq(2000)
+            expect(new_instance.recognition_timeout).to eq(0)
             expect(new_instance.sensitivity).to eq(0.5)
             expect(new_instance.min_confidence).to eq(0.5)
           end
@@ -148,6 +155,7 @@ module Punchblock
        language="en-US"
        initial-timeout="2000"
        inter-digit-timeout="2000"
+       recognition-timeout="0"
        sensitivity="0.5"
        min-confidence="0.5">
   <grammar content-type="application/grammar+custom">
@@ -202,6 +210,11 @@ module Punchblock
         describe '#inter_digit_timeout' do
           subject { super().inter_digit_timeout }
           it { should be == 2000 }
+        end
+
+        describe '#recognition_timeout' do
+          subject { super().recognition_timeout }
+          it { should be == 0 }
         end
 
         describe '#sensitivity' do

--- a/spec/punchblock/translator/asterisk/component/mrcp_prompt_spec.rb
+++ b/spec/punchblock/translator/asterisk/component/mrcp_prompt_spec.rb
@@ -511,6 +511,45 @@ module Punchblock
             end
           end
 
+          describe 'Input#recognition-timeout' do
+            context 'a positive number' do
+              let(:input_command_opts) { { recognition_timeout: 1000 } }
+
+              it 'should pass the t option to SynthAndRecog' do
+                expect_synthandrecog_with_options(/t=1000/)
+                subject.execute
+              end
+            end
+
+            context '0' do
+              let(:input_command_opts) { { recognition_timeout: 0 } }
+
+              it 'should pass the t option to SynthAndRecog' do
+                expect_synthandrecog_with_options(/t=0/)
+                subject.execute
+              end
+            end
+
+            context 'a negative number' do
+              let(:input_command_opts) { { recognition_timeout: -1000 } }
+
+              it "should return an error and not execute any actions" do
+                subject.execute
+                error = ProtocolError.new.setup 'option error', 'A recognition-timeout value must be -1, 0, or a positive integer.'
+                expect(original_command.response(0.1)).to eq(error)
+              end
+            end
+
+            context 'unset' do
+              let(:input_command_opts) { { recognition_timeout: nil } }
+
+              it 'should not pass any options to SynthAndRecog' do
+                expect_synthandrecog_with_options(//)
+                subject.execute
+              end
+            end
+          end
+
           describe 'Input#inter-digit-timeout' do
             context 'a positive number' do
               let(:input_command_opts) { { inter_digit_timeout: 1000 } }


### PR DESCRIPTION
This allows an application to specify recognition timeout settings on a per `#ask` basis when using Asterisk's UniMRCP module for speech recognition.
