### PR TITLE
Handle a corner case with recognition better

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [develop](https://github.com/adhearsion/punchblock)
   * Bugfix: Prevent Asterisk translator death due to dead DTMF recognizers ([#221](https://github.com/adhearsion/punchblock/pull/221), [adhearsion/adhearsion#479](https://github.com/adhearsion/adhearsion/issues/479))
   * Bugfix: Be more intelligent about only stripping true file extensions off filenames for playback on Asterisk ([adhearsion/adhearsion#482](https://github.com/adhearsion/adhearsion/issues/482))
+  * Bugfix: Handle a corner case crash where a recognition request is interrupted directly after a successful recognition has completed
 
 # [v2.5.2](https://github.com/adhearsion/punchblock/compare/v2.5.1...v2.5.2) - [2014-04-03](https://rubygems.org/gems/punchblock/versions/2.5.2)
   * Bugfix: No longer confound start and stop beeps on record commands (#220)

--- a/lib/punchblock/translator/asterisk/component/mrcp_recog_prompt.rb
+++ b/lib/punchblock/translator/asterisk/component/mrcp_recog_prompt.rb
@@ -38,7 +38,6 @@ module Punchblock
 
           def execute_app(app, *args)
             UniMRCPApp.new(app, *args, unimrcp_app_options).execute @call
-            raise UniMRCPError if @call.channel_var('RECOG_STATUS') == 'ERROR'
           end
 
           def unimrcp_app_options
@@ -85,14 +84,21 @@ module Punchblock
           end
 
           def complete
-            send_complete_event case @call.channel_var('RECOG_COMPLETION_CAUSE')
-            when '000'
-              nlsml = RubySpeech.parse URI.decode(@call.channel_var('RECOG_RESULT'))
-              Punchblock::Component::Input::Complete::Match.new nlsml: nlsml
-            when '001'
-              Punchblock::Component::Input::Complete::NoMatch.new
-            when '002'
-              Punchblock::Component::Input::Complete::NoInput.new
+            case @call.channel_var('RECOG_STATUS') 
+            when 'INTERRUPTED'
+              send_complete_event Punchblock::Component::Input::Complete::NoMatch.new
+            when 'ERROR'
+              raise UniMRCPError
+            else 
+              send_complete_event case @call.channel_var('RECOG_COMPLETION_CAUSE')
+              when '000'
+                nlsml = RubySpeech.parse URI.decode(@call.channel_var('RECOG_RESULT'))
+                Punchblock::Component::Input::Complete::Match.new nlsml: nlsml
+              when '001'
+                Punchblock::Component::Input::Complete::NoMatch.new
+              when '002'
+                Punchblock::Component::Input::Complete::NoInput.new
+              end
             end
           end
         end

--- a/spec/punchblock/translator/asterisk/component/mrcp_prompt_spec.rb
+++ b/spec/punchblock/translator/asterisk/component/mrcp_prompt_spec.rb
@@ -215,6 +215,17 @@ module Punchblock
                     end
                   end
 
+                  context "when the RECOG_STATUS variable is set to 'INTERRUPTED' after a successful recognition" do
+                    let(:recog_status) { 'INTERRUPTED' }
+
+                    it "should send an error complete event" do
+                      expected_complete_reason = Punchblock::Component::Input::Complete::NoMatch.new
+                      expect(mock_call).to receive(:execute_agi_command).and_return code: 200, result: 1
+                      subject.execute
+                      expect(original_command.complete_event(0.1).reason).to eq(expected_complete_reason)
+                    end
+                  end
+
                   context "when the RECOG_STATUS variable is set to 'ERROR'" do
                     let(:recog_status) { 'ERROR' }
 


### PR DESCRIPTION
If we run a series of recognition requests and answer one correctly, and then hang up in the middle of the second (or otherwise cause the recognition to return in the 'INTERRUPTED' state) the complete method reads the old value for RECOG_COMPLETION_CAUSE and attempts to parse an empty string, throwing an exception. Handle a message coming back from a recognition request that is in the 'INTERRUPTED' state in a manner that doesn't cause an unchecked exception to be thrown (thus crashing the call and preventing any post-call actions from occurring)

Add changelog entry

Refactor for style guidelines

See #229 for the initial PR if interested.
