### PR TITLE
add speech-complete-timeout to MRCP headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
   * Feature: Support recognition-timeout settings on UniMRCP-based ASR on Asterisk
   * Feature: Implement redirect command on Asterisk
   * Bugfix: Complete 1-to-1 mapping of UniMRCP RECOG_COMPLETION_CAUSE values to Punchblock::Complete events
+  * Feature: Enable setting 'Speech-Complete-Timeout' value for UniMRCP; necessary to allow additional input after an initial match has been recognized
 
 # [v2.5.3](https://github.com/adhearsion/punchblock/compare/v2.5.2...v2.5.3) - [2014-09-22](https://rubygems.org/gems/punchblock/versions/2.5.3)
   * Bugfix: Prevent Asterisk translator death due to dead DTMF recognizers ([#221](https://github.com/adhearsion/punchblock/pull/221), [adhearsion/adhearsion#479](https://github.com/adhearsion/adhearsion/issues/479))

--- a/lib/punchblock/component/input.rb
+++ b/lib/punchblock/component/input.rb
@@ -37,6 +37,9 @@ module Punchblock
       # @return [Integer] Indicates the amount of time during input that recognition will occur before a timeout is triggered.
       attribute :recognition_timeout, Integer
 
+      # @return [Integer] Indicates the length of time additional input may be accepted following a match before returning the result.
+      attribute :speech_complete_timeout, Integer
+
       attribute :grammars, Array, default: []
       def grammars=(others)
         super others.map { |other| Grammar.new(other) }
@@ -69,7 +72,8 @@ module Punchblock
           'sensitivity' => sensitivity,
           'initial-timeout' => initial_timeout,
           'inter-digit-timeout' => inter_digit_timeout,
-          'recognition-timeout' => recognition_timeout
+          'recognition-timeout' => recognition_timeout,
+          'speech-complete-timeout' => speech_complete_timeout
         }
       end
 

--- a/lib/punchblock/translator/asterisk/component/mrcp_recog_prompt.rb
+++ b/lib/punchblock/translator/asterisk/component/mrcp_recog_prompt.rb
@@ -35,6 +35,7 @@ module Punchblock
             raise OptionError, "An initial-timeout value must be -1 or a positive integer." if @initial_timeout < -1
             raise OptionError, "An inter-digit-timeout value must be -1 or a positive integer." if @inter_digit_timeout < -1
             raise OptionError, "A recognition-timeout value must be -1, 0, or a positive integer." if @recognition_timeout < -1
+            raise OptionError, "A speech-complete-timeout value must be a positive integer."  if @speech_complete_timeout < -1
           end
 
           def execute_app(app, *args)
@@ -50,6 +51,7 @@ module Punchblock
               opts[:ct] = input_node.min_confidence if input_node.min_confidence
               opts[:sl] = input_node.sensitivity if input_node.sensitivity
               opts[:t]  = input_node.recognition_timeout if @recognition_timeout > -1
+              opts[:sct] = input_node.speech_complete_timeout if @speech_complete_timeout > -1
               yield opts
             end
           end
@@ -58,6 +60,7 @@ module Punchblock
             @initial_timeout = input_node.initial_timeout || -1
             @inter_digit_timeout = input_node.inter_digit_timeout || -1
             @recognition_timeout = input_node.recognition_timeout || -1
+            @speech_complete_timeout = input_node.speech_complete_timeout || -1
           end
 
           def grammars

--- a/spec/punchblock/component/input_spec.rb
+++ b/spec/punchblock/component/input_spec.rb
@@ -12,16 +12,17 @@ module Punchblock
       describe "when setting options in initializer" do
         subject do
           described_class.new grammar: {value: '[5 DIGITS]', content_type: 'application/grammar+custom'},
-                    :mode                 => :voice,
-                    :terminator           => '#',
-                    :max_silence          => 1000,
-                    :recognizer           => 'default',
-                    :language             => 'en-US',
-                    :initial_timeout      => 2000,
-                    :inter_digit_timeout  => 2000,
-                    :recognition_timeout  => 0,
-                    :sensitivity          => 0.5,
-                    :min_confidence       => 0.5
+                    :mode                    => :voice,
+                    :terminator              => '#',
+                    :max_silence             => 1000,
+                    :recognizer              => 'default',
+                    :language                => 'en-US',
+                    :initial_timeout         => 2000,
+                    :inter_digit_timeout     => 2000,
+                    :recognition_timeout     => 0,
+                    :speech_complete_timeout => 0,
+                    :sensitivity             => 0.5,
+                    :min_confidence          => 0.5
         end
 
         describe '#grammars' do
@@ -66,6 +67,11 @@ module Punchblock
 
         describe '#recognition_timeout' do
           subject { super().recognition_timeout }
+          it { should be == 0 }
+        end
+
+        describe '#speech_complete_timeout' do
+          subject { super().speech_complete_timeout }
           it { should be == 0 }
         end
 
@@ -156,6 +162,7 @@ module Punchblock
        initial-timeout="2000"
        inter-digit-timeout="2000"
        recognition-timeout="0"
+       speech-complete-timeout="0"
        sensitivity="0.5"
        min-confidence="0.5">
   <grammar content-type="application/grammar+custom">

--- a/spec/punchblock/translator/asterisk/component/mrcp_prompt_spec.rb
+++ b/spec/punchblock/translator/asterisk/component/mrcp_prompt_spec.rb
@@ -589,6 +589,36 @@ module Punchblock
             end
           end
 
+          describe 'Input#speech-complete-timeout' do
+            context 'a positive number' do
+              let(:input_command_opts) { { speech_complete_timeout: 1000 } }
+
+              it 'should pass the dit option to SynthAndRecog' do
+                expect_synthandrecog_with_options(/sct=1000/)
+                subject.execute
+              end
+            end
+
+            context 'unset' do
+              let(:input_command_opts) { { speech_complete_timeout: nil } }
+
+              it 'should not pass any options to SynthAndRecog' do
+                expect_synthandrecog_with_options(//)
+                subject.execute
+              end
+            end
+
+            context 'a negative number other than -1' do
+              let(:input_command_opts) { { speech_complete_timeout: -1000 } }
+
+              it "should return an error and not execute any actions" do
+                subject.execute
+                error = ProtocolError.new.setup 'option error', 'A speech-complete-timeout value must be -1 or a positive integer.'
+                expect(original_command.response(0.1)).to eq(error)
+              end
+            end
+          end
+
           describe 'Input#mode' do
             pending
           end


### PR DESCRIPTION
When using Asterisk UniMRCP. See [Rayo](https://github.com/rayo/xmpp/pull/96) for corresponding protocol change.