### PR TITLE
add dtmf-term-timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
   * Feature: Support recognition-timeout settings on UniMRCP-based ASR on Asterisk
   * Feature: Implement redirect command on Asterisk
   * Bugfix: Complete 1-to-1 mapping of UniMRCP RECOG_COMPLETION_CAUSE values to Punchblock::Complete events
+  * Feature: Enable setting 'Dtmf-Term-Timeout' value for UniMRCP; necessary to exit sooner from successful Lumenvox recognition event
 
 # [v2.5.3](https://github.com/adhearsion/punchblock/compare/v2.5.2...v2.5.3) - [2014-09-22](https://rubygems.org/gems/punchblock/versions/2.5.3)
   * Bugfix: Prevent Asterisk translator death due to dead DTMF recognizers ([#221](https://github.com/adhearsion/punchblock/pull/221), [adhearsion/adhearsion#479](https://github.com/adhearsion/adhearsion/issues/479))

--- a/lib/punchblock/component/input.rb
+++ b/lib/punchblock/component/input.rb
@@ -33,6 +33,9 @@ module Punchblock
 
       # @return [Integer] Indicates (in the case of DTMF input) the amount of time (in milliseconds) between input digits which may expire before a timeout is triggered.
       attribute :inter_digit_timeout, Integer
+      #
+      # @return [Integer] Indicates (in the case of DTMF input) the amount of time between input digits which may expire before a match is returned.
+      attribute :dtmf_term_timeout, Integer
 
       # @return [Integer] Indicates the amount of time during input that recognition will occur before a timeout is triggered.
       attribute :recognition_timeout, Integer
@@ -69,6 +72,7 @@ module Punchblock
           'sensitivity' => sensitivity,
           'initial-timeout' => initial_timeout,
           'inter-digit-timeout' => inter_digit_timeout,
+          'dtmf-term-timeout' => dtmf_term_timeout,
           'recognition-timeout' => recognition_timeout
         }
       end

--- a/lib/punchblock/translator/asterisk/component/mrcp_recog_prompt.rb
+++ b/lib/punchblock/translator/asterisk/component/mrcp_recog_prompt.rb
@@ -35,6 +35,7 @@ module Punchblock
             raise OptionError, "An initial-timeout value must be -1 or a positive integer." if @initial_timeout < -1
             raise OptionError, "An inter-digit-timeout value must be -1 or a positive integer." if @inter_digit_timeout < -1
             raise OptionError, "A recognition-timeout value must be -1, 0, or a positive integer." if @recognition_timeout < -1
+            raise OptionError, "A dtmf-term-timeout value must be -1, 0, or a positive integer." if @dtmf_term_timeout < -1
           end
 
           def execute_app(app, *args)
@@ -50,6 +51,7 @@ module Punchblock
               opts[:ct] = input_node.min_confidence if input_node.min_confidence
               opts[:sl] = input_node.sensitivity if input_node.sensitivity
               opts[:t]  = input_node.recognition_timeout if @recognition_timeout > -1
+              opts[:dtt] = input_node.dtmf_term_timeout if @dtmf_term_timeout > -1
               yield opts
             end
           end
@@ -58,6 +60,7 @@ module Punchblock
             @initial_timeout = input_node.initial_timeout || -1
             @inter_digit_timeout = input_node.inter_digit_timeout || -1
             @recognition_timeout = input_node.recognition_timeout || -1
+            @dtmf_term_timeout = input_node.dtmf_term_timeout || -1
           end
 
           def grammars

--- a/spec/punchblock/component/input_spec.rb
+++ b/spec/punchblock/component/input_spec.rb
@@ -20,6 +20,7 @@ module Punchblock
                     :initial_timeout      => 2000,
                     :inter_digit_timeout  => 2000,
                     :recognition_timeout  => 0,
+                    :dtmf_term_timeout    => 0,
                     :sensitivity          => 0.5,
                     :min_confidence       => 0.5
         end
@@ -66,6 +67,11 @@ module Punchblock
 
         describe '#recognition_timeout' do
           subject { super().recognition_timeout }
+          it { should be == 0 }
+        end
+
+        describe '#dtmf_term_timeout' do
+          subject { super().dtmf_term_timeout }
           it { should be == 0 }
         end
 
@@ -125,6 +131,7 @@ module Punchblock
             expect(new_instance.initial_timeout).to eq(2000)
             expect(new_instance.inter_digit_timeout).to eq(2000)
             expect(new_instance.recognition_timeout).to eq(0)
+            expect(new_instance.dtmf_term_timeout).to eq(0)
             expect(new_instance.sensitivity).to eq(0.5)
             expect(new_instance.min_confidence).to eq(0.5)
           end
@@ -156,6 +163,7 @@ module Punchblock
        initial-timeout="2000"
        inter-digit-timeout="2000"
        recognition-timeout="0"
+       dtmf-term-timeout="0"
        sensitivity="0.5"
        min-confidence="0.5">
   <grammar content-type="application/grammar+custom">

--- a/spec/punchblock/translator/asterisk/component/mrcp_prompt_spec.rb
+++ b/spec/punchblock/translator/asterisk/component/mrcp_prompt_spec.rb
@@ -550,6 +550,45 @@ module Punchblock
             end
           end
 
+          describe 'Input#dtmf-term-timeout' do
+            context 'a positive number' do
+              let(:input_command_opts) { { dtmf_term_timeout: 500 } }
+
+              it 'should pass the dtt option to SynthAndRecog' do
+                expect_synthandrecog_with_options(/dtt=500/)
+                subject.execute
+              end
+            end
+
+            context '0' do
+              let(:input_command_opts) { { dtmf_term_timeout: 0 } }
+
+              it 'should pass the dtt option to SynthAndRecog' do
+                expect_synthandrecog_with_options(/dtt=0/)
+                subject.execute
+              end
+            end
+
+            context 'a negative number' do
+              let(:input_command_opts) { { dtmf_term_timeout: -1000 } }
+
+              it "should return an error and not execute any actions" do
+                subject.execute
+                error = ProtocolError.new.setup 'option error', 'A dtmf-term-timeout value must be -1, 0, or a positive integer.'
+                expect(original_command.response(0.1)).to eq(error)
+              end
+            end
+
+            context 'unset' do
+              let(:input_command_opts) { { dtmf_term_timeout: nil } }
+
+              it 'should not pass any options to SynthAndRecog' do
+                expect_synthandrecog_with_options(//)
+                subject.execute
+              end
+            end
+          end
+
           describe 'Input#inter-digit-timeout' do
             context 'a positive number' do
               let(:input_command_opts) { { inter_digit_timeout: 1000 } }


### PR DESCRIPTION
when using Asterisk UniMRCP.  See [Rayo](https://github.com/rayo/xmpp/pull/96) for corresponding protocol change.