### PR TITLE
Open up Celluloid dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
   * Feature: Support recognition-timeout settings on UniMRCP-based ASR on Asterisk
   * Feature: Implement redirect command on Asterisk
   * Bugfix: Complete 1-to-1 mapping of UniMRCP RECOG_COMPLETION_CAUSE values to Punchblock::Complete events
+  * Update: Open Celluloid dependency, so Punchblock can be used with gems requiring Celluloid 0.16
 
 # [v2.5.3](https://github.com/adhearsion/punchblock/compare/v2.5.2...v2.5.3) - [2014-09-22](https://rubygems.org/gems/punchblock/versions/2.5.3)
   * Bugfix: Prevent Asterisk translator death due to dead DTMF recognizers ([#221](https://github.com/adhearsion/punchblock/pull/221), [adhearsion/adhearsion#479](https://github.com/adhearsion/adhearsion/issues/479))

--- a/punchblock.gemspec
+++ b/punchblock.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency %q<state_machine>, ["~> 1.0"]
   s.add_runtime_dependency %q<future-resource>, ["~> 1.0"]
   s.add_runtime_dependency %q<has-guarded-handlers>, ["~> 1.5"]
-  s.add_runtime_dependency %q<celluloid>, ["~> 0.15.2"]
+  s.add_runtime_dependency %q<celluloid>, ["~> 0.15", ">= 0.15.2"]
   s.add_runtime_dependency %q<ruby_ami>, ["~> 2.2"]
   s.add_runtime_dependency %q<ruby_fs>, ["~> 1.1"]
   s.add_runtime_dependency %q<ruby_speech>, ["~> 2.3"]


### PR DESCRIPTION
Otherwise Punchblock cannot be used with gems requiring Celluloid 0.16, which blocks upgrading Adhearsion's Celluloid dependency.