### PR TITLE
[BUGFIX] Handle an illegal AMI response by Asterisk as a failure with code -1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
   * Feature: Support recognition-timeout settings on UniMRCP-based ASR on Asterisk
   * Feature: Implement redirect command on Asterisk
   * Bugfix: Complete 1-to-1 mapping of UniMRCP RECOG_COMPLETION_CAUSE values to Punchblock::Complete events
+  * Bugfix: Handle an illegal AMI response by Asterisk as a failure with code -1
 
 # [v2.5.3](https://github.com/adhearsion/punchblock/compare/v2.5.2...v2.5.3) - [2014-09-22](https://rubygems.org/gems/punchblock/versions/2.5.3)
   * Bugfix: Prevent Asterisk translator death due to dead DTMF recognizers ([#221](https://github.com/adhearsion/punchblock/pull/221), [adhearsion/adhearsion#479](https://github.com/adhearsion/adhearsion/issues/479))

--- a/lib/punchblock/translator/asterisk/agi_command.rb
+++ b/lib/punchblock/translator/asterisk/agi_command.rb
@@ -23,6 +23,9 @@ module Punchblock
         def parse_result(event)
           parser = RubyAMI::AGIResultParser.new event['Result']
           {code: parser.code, result: parser.result, data: parser.data}
+        rescue ArgumentError => e
+          pb_logger.warn "Illegal message received from Asterisk: #{e.message}"
+          {code: -1, result: nil, data: nil}
         end
 
         private


### PR DESCRIPTION
This PR addresses an issue with a translator crash happening when an AMI response contains illegal characters such as $.
The underlying issue is actually an Asterisk bug, but this fix loses a single call instead of crashing entirely.