### PR TITLE
MRCPRecog doesn't work with SSML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [develop](https://github.com/adhearsion/punchblock)
   * Bugfix: Handle an illegal AMI response by Asterisk as a failure with code -1
   * Bugfix: Ensure a useful error is raised when attempting to join to a call which doesn't exist [#529](https://github.com/adhearsion/adhearsion/issues/529)
+  * Bugfix: Support SSML in MRCPRecog case on Asterisk. This is the case where a prompt component wants to render using Asterisk and recognise using UniMRCP. This worked fine with a uri-list which already has test coverage, but threw (and silently swallowed) an exception for an SSML doc (as provided by Adhearsion) resulting in a hung call with no audio, and then a timeout exception in Adhearsion. [#241](https://github.com/adhearsion/punchblock/pull/241)
 
 # [v2.6.0](https://github.com/adhearsion/punchblock/compare/v2.5.3...v2.6.0) - [2015-02-01](https://rubygems.org/gems/punchblock/versions/2.6.0)
   * Feature: Support recognition-timeout settings on UniMRCP-based ASR on Asterisk ([#228](https://github.com/adhearsion/punchblock/pull/228))

--- a/lib/punchblock/component/output.rb
+++ b/lib/punchblock/component/output.rb
@@ -46,6 +46,18 @@ module Punchblock
           super
         end
 
+        def size
+          if ssml?
+            value.children.count
+          else
+            value.size
+          end
+        end
+
+        def ssml?
+          content_type == SSML_CONTENT_TYPE
+        end
+
         private
 
         def xml_value
@@ -56,10 +68,6 @@ module Punchblock
           elsif
             value
           end
-        end
-
-        def ssml?
-          content_type == SSML_CONTENT_TYPE
         end
 
         def urilist?

--- a/lib/punchblock/translator/asterisk/component/mrcp_native_prompt.rb
+++ b/lib/punchblock/translator/asterisk/component/mrcp_native_prompt.rb
@@ -41,10 +41,18 @@ module Punchblock
           end
 
           def audio_filename
-            if first_doc.ssml?
+            path = if first_doc.ssml?
               first_doc.value.children.first.src
             else
               first_doc.value.first
+            end.sub('file://', '')
+
+            dir = File.dirname(path)
+            basename = File.basename(path, '.*')
+            if dir == '.'
+              basename
+            else
+              File.join(dir, basename)
             end
           end
 

--- a/lib/punchblock/translator/asterisk/component/mrcp_native_prompt.rb
+++ b/lib/punchblock/translator/asterisk/component/mrcp_native_prompt.rb
@@ -17,7 +17,7 @@ module Punchblock
             raise OptionError, 'A document is required.' unless output_node.render_documents.count > 0
             raise OptionError, 'Only one document is allowed.' if output_node.render_documents.count > 1
             raise OptionError, 'Only inline documents are allowed.' if first_doc.url
-            raise OptionError, 'Only one audio file is allowed.' if first_doc.value.size > 1
+            raise OptionError, 'Only one audio file is allowed.' if first_doc.size > 1
 
             raise OptionError, 'A grammar is required.' unless input_node.grammars.count > 0
 
@@ -41,7 +41,11 @@ module Punchblock
           end
 
           def audio_filename
-            first_doc.value.first
+            if first_doc.ssml?
+              first_doc.value.children.first.src
+            else
+              first_doc.value.first
+            end
           end
 
           def unimrcp_app_options

--- a/spec/punchblock/translator/asterisk/component/mrcp_native_prompt_spec.rb
+++ b/spec/punchblock/translator/asterisk/component/mrcp_native_prompt_spec.rb
@@ -51,10 +51,11 @@ module Punchblock
 
           let(:output_command_opts) { {} }
 
-          let(:audio_filename) { 'http://example.com/hello.mp3' }
+          let(:audio_filename) { '/var/foo' }
+          let(:audio_path) { "file://#{audio_filename}.wav" }
 
           let :output_command_options do
-            { render_document: {value: [audio_filename], content_type: 'text/uri-list'} }.merge(output_command_opts)
+            { render_document: {value: [audio_path], content_type: 'text/uri-list'} }.merge(output_command_opts)
           end
 
           let(:input_command_opts) { {} }
@@ -161,8 +162,8 @@ module Punchblock
             context 'with multiple audio tags in SSML' do
               let :ssml_doc do
                 RubySpeech::SSML.draw do
-                  audio(src: audio_filename)
-                  audio(src: audio_filename)
+                  audio(src: audio_path)
+                  audio(src: audio_path)
                 end
               end
 
@@ -201,7 +202,7 @@ module Punchblock
                 context "when the render document is SSML" do
                   let :ssml_doc do
                     RubySpeech::SSML.draw do
-                      audio(src: audio_filename)
+                      audio(src: audio_path)
                     end
                   end
 


### PR DESCRIPTION
This is the case where a prompt component wants to render using Asterisk and recognise using UniMRCP. This works fine with a uri-list which already has test coverage, but throws (and silently swallows??) an exception for an SSML doc (as provided by Adhearsion) resulting in a hung call with no audio, and then a timeout exception in Adhearsion.