### PR TITLE
Fixed a memory leak caused by Punchblock::Translator::Asterisk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [develop](https://github.com/adhearsion/punchblock)
+  * Bugfix: Ensure components are deregistered from asterisk translator once the call is ended ([#250](https://github.com/adhearsion/punchblock/pull/250))
 
 # [v2.7.0](https://github.com/adhearsion/punchblock/compare/v2.6.0...v2.7.0) - [2015-06-09](https://rubygems.org/gems/punchblock/versions/2.7.0)
   * Feature: Support for Asterisk 13 (AMI v2)

--- a/lib/punchblock/translator/asterisk.rb
+++ b/lib/punchblock/translator/asterisk.rb
@@ -72,6 +72,10 @@ module Punchblock
         @components[component.id] ||= component
       end
 
+      def deregister_component(id)
+        @components.delete id
+      end
+
       def component_with_id(component_id)
         @components[component_id]
       end

--- a/lib/punchblock/translator/asterisk/component.rb
+++ b/lib/punchblock/translator/asterisk/component.rb
@@ -40,6 +40,7 @@ module Punchblock
             event = Punchblock::Event::Complete.new reason: reason, recording: recording
             send_event event
             call.deregister_component id if call
+            translator.deregister_component id
           end
 
           def send_event(event)

--- a/spec/punchblock/translator/asterisk/component_spec.rb
+++ b/spec/punchblock/translator/asterisk/component_spec.rb
@@ -58,6 +58,14 @@ module Punchblock
               expect(subject).to receive(:send_complete_event).once.with Punchblock::Event::Complete::Hangup.new
               subject.call_ended
             end
+
+            it "should deregister component from translator" do
+              translator.register_component(subject)
+              expect(translator.component_with_id(subject.id)).not_to be nil
+              expect(translator).to receive(:handle_pb_event).once
+              subject.call_ended
+              expect(translator.component_with_id(subject.id)).to be nil
+            end
           end
 
           describe '#execute_command' do


### PR DESCRIPTION
There's a memory leak in Punchblock (asterisk platform) caused by `Punchblock::Translator::Asterisk` that detains references to `Punchblock::Translator::Asterisk::Component::Asterisk::AMIAction` objects even after the call is ended.

Per each call a new `Punchblock::Translator::Asterisk::Component::Asterisk::AMIAction` is created here:

https://github.com/adhearsion/punchblock/blob/develop/lib/punchblock/translator/asterisk.rb#L143

and then registered into `Punchblock::Translator::Asterisk` as a component object. The problem is that those `Punchblock::Translator::Asterisk::Component::Asterisk::AMIAction` objects are never garbage collected, because the reference to them is never removed.

The solution is to deregister the component when the complete event is received.

The memory leak could be seen by counting the number of `Punchblock::Translator::Asterisk::Component::Asterisk::AMIAction` in `ObjectSpace`:

```ruby
ObjectSpace.each_object(Punchblock::Translator::Asterisk::Component::Asterisk::AMIAction).count
```

The number of those objects grows continuously.