### PR TITLE
Avoid race conditions in processing calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # [develop](https://github.com/adhearsion/punchblock)
+
+# [v2.7.4](https://github.com/adhearsion/punchblock/compare/v2.7.3...v2.7.4) - [2015-08-19](https://rubygems.org/gems/punchblock/versions/2.7.4)
   * Bugfix: Avoid race conditions in processing calls with interactions between them
 
 # [v2.7.3](https://github.com/adhearsion/punchblock/compare/v2.7.2...v2.7.3) - [2015-08-18](https://rubygems.org/gems/punchblock/versions/2.7.3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [develop](https://github.com/adhearsion/punchblock)
+  * Bugfix: Avoid race conditions in processing calls with interactions between them
 
 # [v2.7.3](https://github.com/adhearsion/punchblock/compare/v2.7.2...v2.7.3) - [2015-08-18](https://rubygems.org/gems/punchblock/versions/2.7.3)
   * Bugfix: Handle correct event for confirming that a component stop was completed on Asterisk 13

--- a/lib/punchblock/translator/asterisk.rb
+++ b/lib/punchblock/translator/asterisk.rb
@@ -151,7 +151,7 @@ module Punchblock
           if call = call_with_id(command.uri)
             command.response = ProtocolError.new.setup(:conflict, 'Call ID already in use')
           else
-            call = Call.new command.to, current_actor, ami_client, connection, nil, command.uri
+            call = Call.new command.to, self, ami_client, connection, nil, command.uri
             register_call call
             call.dial command
           end
@@ -231,7 +231,7 @@ module Punchblock
 
         return if env[:agi_extension] == 'h' || env[:agi_type] == 'Kill'
 
-        call = Call.new event['Channel'], current_actor, ami_client, connection, env
+        call = Call.new event['Channel'], self, ami_client, connection, env
         register_call call
         call.send_offer
       end

--- a/lib/punchblock/version.rb
+++ b/lib/punchblock/version.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
 
 module Punchblock
-  VERSION = "2.7.3"
+  VERSION = "2.7.4"
 end


### PR DESCRIPTION
Methods called on Asterisk calls are always dispatched through the translator. Those which call back to the translator should do so within the task rather than exposing race conditions (and performance impact) of calling back through the translator actor proxy.