### PR TITLE
Ensure that punchblock uses .WAV extension for wav49 format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # [develop](https://github.com/adhearsion/punchblock)
+  * Bugfix: Return correct recording uri for wav49 format with Asterisk.
   * Change: Remove support for FreeSWITCH translator on Inbound EventSocket
   * Bugfix: Return the correct error when the call is down when stopping an output rather than crashing the translator ([#256](https://github.com/adhearsion/punchblock/pull/256))
   * Bugfix: Handle more AMI error responses which mean the channel is not found

--- a/lib/punchblock/translator/asterisk/component/record.rb
+++ b/lib/punchblock/translator/asterisk/component/record.rb
@@ -80,7 +80,8 @@ module Punchblock
           end
 
           def recording
-            Punchblock::Component::Record::Recording.new :uri => "file://#{filename}.#{@format}"
+            ext = @format.gsub('wav49', 'WAV')
+            Punchblock::Component::Record::Recording.new :uri => "file://#{filename}.#{ext}"
           end
 
           def stop_reason

--- a/spec/punchblock/translator/asterisk/component/record_spec.rb
+++ b/spec/punchblock/translator/asterisk/component/record_spec.rb
@@ -200,6 +200,23 @@ module Punchblock
                   expect(recording.uri).to match(/.*\.mp3$/)
                 end
               end
+
+              context "set to 'wav49'" do
+                let(:command_options) { { :format => 'wav49' } }
+                it "should execute as 'wav49'" do
+                  expect(ami_client).to receive(:send_action).once.with('Monitor', hash_including('Format' => 'wav49'))
+                  subject.execute
+                  expect(original_command.response(0.1)).to be_a Ref
+                end
+
+                it "provides the correct filename in the recording" do
+                  expect(ami_client).to receive(:send_action)
+                  subject.execute
+                  monitor_stop_event = RubyAMI::Event.new 'MonitorStop', 'Channel' => channel
+                  mock_call.process_ami_event monitor_stop_event
+                  expect(recording.uri).to match(/.*\.WAV$/)
+                end
+              end
             end
 
             describe 'start_beep' do


### PR DESCRIPTION
Ensures that the uri returned when wav49 format is used, has the same file extension as what asterisk will use.
